### PR TITLE
Change update endpoints to PUT instead of PATCH

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
@@ -17,9 +17,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,7 +45,7 @@ public class MappingController {
   }
 
   @PreAuthorize("isAuthenticated()")
-  @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PutMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<MappingRecord> updateMapping(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       @RequestBody Mapping mapping) {

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,7 +41,7 @@ public class SourceSystemController {
   }
 
   @PreAuthorize("isAuthenticated()")
-  @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PutMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<SourceSystemRecord> updateSourceSystem(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       @RequestBody SourceSystem sourceSystem) {


### PR DESCRIPTION
[Jira](https://naturalis.atlassian.net/browse/DD-310?atlOrigin=eyJpIjoiNWM4MTNlNDM3OTg4NDFmMDk1NzdhYTU2YTc5OGY2MDMiLCJwIjoiaiJ9)

Strictly speaking, PUT replaces an entire resource, while PATCH modifies an existing resource (and so not all fields are required in this kind of request). In the orchestration service, we replace an entire resource with our update requests, so they should be PUT requests. 