### PR TITLE
Feature/add delete endpoint

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
@@ -3,6 +3,7 @@ package eu.dissco.orchestration.backend.controller;
 import eu.dissco.orchestration.backend.domain.Mapping;
 import eu.dissco.orchestration.backend.domain.MappingRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.service.MappingService;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.transform.TransformerException;
@@ -16,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,6 +55,16 @@ public class MappingController {
     log.info("Received update request for mapping: {}", id);
     var result = service.updateMapping(id, mapping, getNameFromToken(authentication));
     return ResponseEntity.ok(result);
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Void> deleteMapping(@PathVariable("prefix") String prefix,
+      @PathVariable("postfix") String postfix) throws NotFoundException {
+    String id = prefix + "/" + postfix;
+    service.deleteMapping(id);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
@@ -17,7 +17,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,7 +52,12 @@ public class MappingController {
       @RequestBody Mapping mapping) {
     var id = prefix + '/' + suffix;
     log.info("Received update request for mapping: {}", id);
-    var result = service.updateMapping(id, mapping, getNameFromToken(authentication));
+    MappingRecord result = null;
+    try {
+      result = service.updateMapping(id, mapping, getNameFromToken(authentication));
+    } catch (NotFoundException e) {
+      throw new RuntimeException(e);
+    }
     return ResponseEntity.ok(result);
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
@@ -49,15 +49,11 @@ public class MappingController {
   @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<MappingRecord> updateMapping(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
-      @RequestBody Mapping mapping) {
+      @RequestBody Mapping mapping) throws NotFoundException{
     var id = prefix + '/' + suffix;
     log.info("Received update request for mapping: {}", id);
     MappingRecord result = null;
-    try {
-      result = service.updateMapping(id, mapping, getNameFromToken(authentication));
-    } catch (NotFoundException e) {
-      throw new RuntimeException(e);
-    }
+    result = service.updateMapping(id, mapping, getNameFromToken(authentication));
     return ResponseEntity.ok(result);
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -59,7 +60,7 @@ public class MappingController {
 
   @PreAuthorize("isAuthenticated()")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @DeleteMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> deleteMapping(@PathVariable("prefix") String prefix,
       @PathVariable("postfix") String postfix) throws NotFoundException {
     String id = prefix + "/" + postfix;

--- a/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MappingController.java
@@ -59,7 +59,7 @@ public class MappingController {
 
   @PreAuthorize("isAuthenticated()")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @DeleteMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> deleteMapping(@PathVariable("prefix") String prefix,
       @PathVariable("postfix") String postfix) throws NotFoundException {
     String id = prefix + "/" + postfix;

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -3,6 +3,7 @@ package eu.dissco.orchestration.backend.controller;
 import eu.dissco.orchestration.backend.domain.SourceSystem;
 import eu.dissco.orchestration.backend.domain.SourceSystemRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.service.SourceSystemService;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.transform.TransformerException;
@@ -13,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -70,6 +72,16 @@ public class SourceSystemController {
   ){
     String path = SANDBOX_URI + r.getRequestURI();
     return ResponseEntity.status(HttpStatus.OK).body(service.getSourceSystemRecords(pageNum, pageSize, path));
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Void> deleteSourceSystem(@PathVariable("prefix") String prefix,
+      @PathVariable("postfix") String postfix) throws NotFoundException {
+    String id = prefix + "/" + postfix;
+    service.deleteSourceSystem(id);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 
 }

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -77,7 +77,7 @@ public class SourceSystemController {
 
   @PreAuthorize("isAuthenticated()")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @DeleteMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> deleteSourceSystem(@PathVariable("prefix") String prefix,
       @PathVariable("postfix") String postfix) throws NotFoundException {
     String id = prefix + "/" + postfix;

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,10 +44,10 @@ public class SourceSystemController {
   }
 
   @PreAuthorize("isAuthenticated()")
-  @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PutMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<SourceSystemRecord> updateSourceSystem(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
-      @RequestBody SourceSystem sourceSystem) {
+      @RequestBody SourceSystem sourceSystem) throws NotFoundException {
     var id = prefix + '/' + suffix;
     log.info("Received update request for source system: {}", id);
     var result = service.updateSourceSystem(id, sourceSystem);

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -16,7 +16,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -76,7 +76,7 @@ public class SourceSystemController {
 
   @PreAuthorize("isAuthenticated()")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @DeleteMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> deleteSourceSystem(@PathVariable("prefix") String prefix,
       @PathVariable("postfix") String postfix) throws NotFoundException {
     String id = prefix + "/" + postfix;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/DefaultCatalog.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/DefaultCatalog.java
@@ -6,7 +6,6 @@ package eu.dissco.orchestration.backend.database.jooq;
 
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Schema;
 import org.jooq.impl.CatalogImpl;
 

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/Indexes.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/Indexes.java
@@ -5,7 +5,6 @@ package eu.dissco.orchestration.backend.database.jooq;
 
 
 import eu.dissco.orchestration.backend.database.jooq.tables.Handles;
-
 import org.jooq.Index;
 import org.jooq.OrderField;
 import org.jooq.impl.DSL;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/Keys.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/Keys.java
@@ -10,7 +10,6 @@ import eu.dissco.orchestration.backend.database.jooq.tables.NewSourceSystem;
 import eu.dissco.orchestration.backend.database.jooq.tables.records.HandlesRecord;
 import eu.dissco.orchestration.backend.database.jooq.tables.records.NewMappingRecord;
 import eu.dissco.orchestration.backend.database.jooq.tables.records.NewSourceSystemRecord;
-
 import org.jooq.TableField;
 import org.jooq.UniqueKey;
 import org.jooq.impl.DSL;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/Public.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/Public.java
@@ -7,10 +7,8 @@ package eu.dissco.orchestration.backend.database.jooq;
 import eu.dissco.orchestration.backend.database.jooq.tables.Handles;
 import eu.dissco.orchestration.backend.database.jooq.tables.NewMapping;
 import eu.dissco.orchestration.backend.database.jooq.tables.NewSourceSystem;
-
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Catalog;
 import org.jooq.Table;
 import org.jooq.impl.SchemaImpl;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/Handles.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/Handles.java
@@ -8,10 +8,8 @@ import eu.dissco.orchestration.backend.database.jooq.Indexes;
 import eu.dissco.orchestration.backend.database.jooq.Keys;
 import eu.dissco.orchestration.backend.database.jooq.Public;
 import eu.dissco.orchestration.backend.database.jooq.tables.records.HandlesRecord;
-
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Field;
 import org.jooq.ForeignKey;
 import org.jooq.Index;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/NewMapping.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/NewMapping.java
@@ -7,11 +7,9 @@ package eu.dissco.orchestration.backend.database.jooq.tables;
 import eu.dissco.orchestration.backend.database.jooq.Keys;
 import eu.dissco.orchestration.backend.database.jooq.Public;
 import eu.dissco.orchestration.backend.database.jooq.tables.records.NewMappingRecord;
-
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Field;
 import org.jooq.ForeignKey;
 import org.jooq.JSONB;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/NewSourceSystem.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/NewSourceSystem.java
@@ -7,11 +7,9 @@ package eu.dissco.orchestration.backend.database.jooq.tables;
 import eu.dissco.orchestration.backend.database.jooq.Keys;
 import eu.dissco.orchestration.backend.database.jooq.Public;
 import eu.dissco.orchestration.backend.database.jooq.tables.records.NewSourceSystemRecord;
-
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-
 import org.jooq.Field;
 import org.jooq.ForeignKey;
 import org.jooq.Name;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/records/HandlesRecord.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/records/HandlesRecord.java
@@ -5,7 +5,6 @@ package eu.dissco.orchestration.backend.database.jooq.tables.records;
 
 
 import eu.dissco.orchestration.backend.database.jooq.tables.Handles;
-
 import org.jooq.Field;
 import org.jooq.Record12;
 import org.jooq.Record2;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/records/NewMappingRecord.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/records/NewMappingRecord.java
@@ -5,9 +5,7 @@ package eu.dissco.orchestration.backend.database.jooq.tables.records;
 
 
 import eu.dissco.orchestration.backend.database.jooq.tables.NewMapping;
-
 import java.time.Instant;
-
 import org.jooq.Field;
 import org.jooq.JSONB;
 import org.jooq.Record2;

--- a/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/records/NewSourceSystemRecord.java
+++ b/src/main/java/eu/dissco/orchestration/backend/database/jooq/tables/records/NewSourceSystemRecord.java
@@ -5,9 +5,7 @@ package eu.dissco.orchestration.backend.database.jooq.tables.records;
 
 
 import eu.dissco.orchestration.backend.database.jooq.tables.NewSourceSystem;
-
 import java.time.Instant;
-
 import org.jooq.Field;
 import org.jooq.Record1;
 import org.jooq.Record7;

--- a/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
@@ -48,6 +48,16 @@ public class MappingRepository {
         .fetchOne(this::mapToMappingRecord);
   }
 
+  public MappingRecord getMappingOmitDeleted(String id) {
+    return context.select(NEW_MAPPING.asterisk())
+        .distinctOn(NEW_MAPPING.ID)
+        .from(NEW_MAPPING)
+        .where(NEW_MAPPING.ID.eq(id))
+        .and(NEW_MAPPING.DELETED.isNull())
+        .orderBy(NEW_MAPPING.ID, NEW_MAPPING.VERSION.desc())
+        .fetchOne(this::mapToMappingRecord);
+  }
+
   public List<MappingRecord> getMappings(int pageNum, int pageSize){
     int offset = getOffset(pageNum, pageSize);
 

--- a/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
@@ -57,18 +57,31 @@ public class MappingRepository {
         .fetch(this::mapToMappingRecord);
   }
 
-  private MappingRecord mapToMappingRecord(Record record) {
+  public int mappingExists(String id){
+    return context.select(NEW_MAPPING.ID)
+        .from(NEW_MAPPING)
+        .where(NEW_MAPPING.ID.eq(id))
+        .and(NEW_MAPPING.DELETED.isNull())
+        .fetch().size();
+  }
+  public void deleteMapping(String id){
+    context.delete(NEW_MAPPING)
+        .where(NEW_MAPPING.ID.eq(id))
+        .execute();
+  }
+
+  private MappingRecord mapToMappingRecord(Record dbRecord) {
     try {
       var mapping = new Mapping(
-          record.get(NEW_MAPPING.NAME),
-          record.get(NEW_MAPPING.DESCRIPTION),
-          mapper.readTree(record.get(NEW_MAPPING.MAPPING).data())
+          dbRecord.get(NEW_MAPPING.NAME),
+          dbRecord.get(NEW_MAPPING.DESCRIPTION),
+          mapper.readTree(dbRecord.get(NEW_MAPPING.MAPPING).data())
       );
       return new MappingRecord(
-          record.get(NEW_MAPPING.ID),
-          record.get(NEW_MAPPING.VERSION),
-          record.get(NEW_MAPPING.CREATED),
-          record.get(NEW_MAPPING.CREATOR),
+          dbRecord.get(NEW_MAPPING.ID),
+          dbRecord.get(NEW_MAPPING.VERSION),
+          dbRecord.get(NEW_MAPPING.CREATED),
+          dbRecord.get(NEW_MAPPING.CREATOR),
           mapping
       );
     } catch (JsonProcessingException e) {

--- a/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
@@ -53,6 +53,7 @@ public class MappingRepository {
 
     return context.select(NEW_MAPPING.asterisk())
         .from(NEW_MAPPING)
+        .where(NEW_MAPPING.DELETED.isNull())
         .offset(offset)
         .limit(pageSize)
         .fetch(this::mapToMappingRecord);

--- a/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.domain.Mapping;
 import eu.dissco.orchestration.backend.domain.MappingRecord;
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
@@ -64,8 +65,9 @@ public class MappingRepository {
         .and(NEW_MAPPING.DELETED.isNull())
         .fetch().size();
   }
-  public void deleteMapping(String id){
-    context.delete(NEW_MAPPING)
+  public void deleteMapping(String id, Instant deleted){
+    context.update(NEW_MAPPING)
+        .set(NEW_MAPPING.DELETED, deleted)
         .where(NEW_MAPPING.ID.eq(id))
         .execute();
   }

--- a/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/MappingRepository.java
@@ -9,6 +9,7 @@ import eu.dissco.orchestration.backend.domain.Mapping;
 import eu.dissco.orchestration.backend.domain.MappingRecord;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
@@ -48,14 +49,14 @@ public class MappingRepository {
         .fetchOne(this::mapToMappingRecord);
   }
 
-  public MappingRecord getMappingOmitDeleted(String id) {
+  public Optional<MappingRecord> getActiveMapping(String id) {
     return context.select(NEW_MAPPING.asterisk())
         .distinctOn(NEW_MAPPING.ID)
         .from(NEW_MAPPING)
         .where(NEW_MAPPING.ID.eq(id))
         .and(NEW_MAPPING.DELETED.isNull())
         .orderBy(NEW_MAPPING.ID, NEW_MAPPING.VERSION.desc())
-        .fetchOne(this::mapToMappingRecord);
+        .fetchOptional(this::mapToMappingRecord);
   }
 
   public List<MappingRecord> getMappings(int pageNum, int pageSize){
@@ -69,13 +70,6 @@ public class MappingRepository {
         .fetch(this::mapToMappingRecord);
   }
 
-  public int mappingExists(String id){
-    return context.select(NEW_MAPPING.ID)
-        .from(NEW_MAPPING)
-        .where(NEW_MAPPING.ID.eq(id))
-        .and(NEW_MAPPING.DELETED.isNull())
-        .fetch().size();
-  }
   public void deleteMapping(String id, Instant deleted){
     context.update(NEW_MAPPING)
         .set(NEW_MAPPING.DELETED, deleted)

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -5,6 +5,7 @@ import static eu.dissco.orchestration.backend.repository.RepositoryUtils.getOffs
 
 import eu.dissco.orchestration.backend.domain.SourceSystem;
 import eu.dissco.orchestration.backend.domain.SourceSystemRecord;
+import java.time.Instant;
 import java.util.List;
 import org.jooq.Record;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +53,9 @@ public class SourceSystemRepository {
         .fetch().size();    
   }
 
-  public void deleteSourceSystem(String id){
-    context.delete(NEW_SOURCE_SYSTEM)
+  public void deleteSourceSystem(String id, Instant deleted){
+    context.update(NEW_SOURCE_SYSTEM)
+        .set(NEW_SOURCE_SYSTEM.DELETED, deleted)
         .where(NEW_SOURCE_SYSTEM.ID.eq(id))
         .execute();
   }

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -7,6 +7,7 @@ import eu.dissco.orchestration.backend.domain.SourceSystem;
 import eu.dissco.orchestration.backend.domain.SourceSystemRecord;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.jooq.Record;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
@@ -38,19 +39,19 @@ public class SourceSystemRepository {
         .where(NEW_SOURCE_SYSTEM.ID.eq(sourceSystemRecord.id())).execute();
   }
 
-  public SourceSystemRecord getSourceSystemById(String id) {
+  public SourceSystemRecord getSourceSystem(String id) {
     return context.select(NEW_SOURCE_SYSTEM.asterisk())
         .from(NEW_SOURCE_SYSTEM)
         .where(NEW_SOURCE_SYSTEM.ID.eq(id))
         .fetchOne(this::mapToSourceSystemRecord);
   }
-  
-  public int sourceSystemExists(String id){
-    return context.select(NEW_SOURCE_SYSTEM.ID)
+
+  public Optional<SourceSystemRecord> getActiveSourceSystem(String id) {
+    return context.select(NEW_SOURCE_SYSTEM.asterisk())
         .from(NEW_SOURCE_SYSTEM)
         .where(NEW_SOURCE_SYSTEM.ID.eq(id))
         .and(NEW_SOURCE_SYSTEM.DELETED.isNull())
-        .fetch().size();    
+        .fetchOptional(this::mapToSourceSystemRecord);
   }
 
   public void deleteSourceSystem(String id, Instant deleted){

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -62,9 +62,9 @@ public class SourceSystemRepository {
 
   public List<SourceSystemRecord> getSourceSystems(int pageNum, int pageSize) {
     int offset = getOffset(pageNum, pageSize);
-    return context.select(NEW_SOURCE_SYSTEM.ID, NEW_SOURCE_SYSTEM.CREATED, NEW_SOURCE_SYSTEM.NAME,
-            NEW_SOURCE_SYSTEM.ENDPOINT, NEW_SOURCE_SYSTEM.DESCRIPTION, NEW_SOURCE_SYSTEM.MAPPING_ID)
+    return context.select(NEW_SOURCE_SYSTEM.asterisk())
         .from(NEW_SOURCE_SYSTEM)
+        .where(NEW_SOURCE_SYSTEM.DELETED.isNull())
         .limit(pageSize)
         .offset(offset)
         .fetch(this::mapToSourceSystemRecord);

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -8,9 +8,9 @@ import eu.dissco.orchestration.backend.domain.SourceSystemRecord;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import org.jooq.Record;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
+import org.jooq.Record;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -43,6 +43,20 @@ public class SourceSystemRepository {
         .where(NEW_SOURCE_SYSTEM.ID.eq(id))
         .fetchOne(this::mapToSourceSystemRecord);
   }
+  
+  public int sourceSystemExists(String id){
+    return context.select(NEW_SOURCE_SYSTEM.ID)
+        .from(NEW_SOURCE_SYSTEM)
+        .where(NEW_SOURCE_SYSTEM.ID.eq(id))
+        .and(NEW_SOURCE_SYSTEM.DELETED.isNull())
+        .fetch().size();    
+  }
+
+  public void deleteSourceSystem(String id){
+    context.delete(NEW_SOURCE_SYSTEM)
+        .where(NEW_SOURCE_SYSTEM.ID.eq(id))
+        .execute();
+  }
 
   public List<SourceSystemRecord> getSourceSystems(int pageNum, int pageSize) {
     int offset = getOffset(pageNum, pageSize);

--- a/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
@@ -33,12 +33,12 @@ public class MappingService {
   }
   public MappingRecord updateMapping(String id, Mapping mapping, String userId)
       throws NotFoundException {
-    var currentVersion = repository.getMappingOmitDeleted(id);
-    if (currentVersion == null){
+    var currentVersion = repository.getActiveMapping(id);
+    if (!currentVersion.isPresent()){
       throw new NotFoundException("Requested mapping does not exist");
     }
-    if (!currentVersion.mapping().equals(mapping)){
-      var mappingRecord = new MappingRecord(id, currentVersion.version() + 1, Instant.now(), userId,
+    if (!currentVersion.get().mapping().equals(mapping)){
+      var mappingRecord = new MappingRecord(id, currentVersion.get().version() + 1, Instant.now(), userId,
           mapping);
       repository.createMapping(mappingRecord);
       return mappingRecord;
@@ -48,12 +48,12 @@ public class MappingService {
   }
 
   public void deleteMapping(String id) throws NotFoundException {
-    int result = repository.mappingExists(id);
-    if (result > 0){
+    var result = repository.getActiveMapping(id);
+    if (result.isPresent()){
       Instant deleted = Instant.now();
       repository.deleteMapping(id, deleted);
     }
-    else throw new NotFoundException("Requested mapping does not exist");
+    else throw new NotFoundException("Requested mapping "+id +" does not exist");
   }
 
   public JsonApiWrapper getMappings(int pageNum, int pageSize, String//When

--- a/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
@@ -46,7 +46,8 @@ public class MappingService {
   public void deleteMapping(String id) throws NotFoundException {
     int result = repository.mappingExists(id);
     if (result > 0){
-      repository.deleteMapping(id);
+      Instant deleted = Instant.now();
+      repository.deleteMapping(id, deleted);
     }
     else throw new NotFoundException("Requested mapping does not exist");
   }

--- a/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
@@ -7,6 +7,7 @@ import eu.dissco.orchestration.backend.domain.MappingRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.repository.MappingRepository;
 import java.time.Instant;
 import java.util.List;
@@ -40,6 +41,14 @@ public class MappingService {
     } else {
       return null;
     }
+  }
+
+  public void deleteMapping(String id) throws NotFoundException {
+    int result = repository.mappingExists(id);
+    if (result > 0){
+      repository.deleteMapping(id);
+    }
+    else throw new NotFoundException("Requested mapping does not exist");
   }
 
   public JsonApiWrapper getMappings(int pageNum, int pageSize, String//When

--- a/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
@@ -31,8 +31,12 @@ public class MappingService {
     repository.createMapping(mappingRecord);
     return mappingRecord;
   }
-  public MappingRecord updateMapping(String id, Mapping mapping, String userId) {
-    var currentVersion = repository.getMapping(id);
+  public MappingRecord updateMapping(String id, Mapping mapping, String userId)
+      throws NotFoundException {
+    var currentVersion = repository.getMappingOmitDeleted(id);
+    if (currentVersion == null){
+      throw new NotFoundException("Requested mapping does not exist");
+    }
     if (!currentVersion.mapping().equals(mapping)){
       var mappingRecord = new MappingRecord(id, currentVersion.version() + 1, Instant.now(), userId,
           mapping);

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -52,7 +52,8 @@ public class SourceSystemService {
   public void deleteSourceSystem(String id) throws NotFoundException {
     int result = repository.sourceSystemExists(id);
     if (result > 0){
-      repository.deleteSourceSystem(id);
+      Instant deleted = Instant.now();
+      repository.deleteSourceSystem(id, deleted);
     }
     else throw new NotFoundException("Requested mapping does not exist");
   }

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -34,7 +34,11 @@ public class SourceSystemService {
     return sourceSystemRecord;
   }
 
-  public SourceSystemRecord updateSourceSystem(String id, SourceSystem sourceSystem) {
+  public SourceSystemRecord updateSourceSystem(String id, SourceSystem sourceSystem) throws NotFoundException{
+    var sourceSystemExists = repository.sourceSystemExists(id);
+    if (sourceSystemExists < 1){
+      throw new NotFoundException("Could not update Source System " + id + ". Verify resource exists.");
+    }
     var sourceSystemRecord = new SourceSystemRecord(id, Instant.now(), sourceSystem);
     repository.updateSourceSystem(sourceSystemRecord);
     return sourceSystemRecord;

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -7,6 +7,7 @@ import eu.dissco.orchestration.backend.domain.SourceSystemRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.repository.SourceSystemRepository;
 import java.time.Instant;
 import java.util.List;
@@ -46,6 +47,14 @@ public class SourceSystemService {
   public JsonApiWrapper getSourceSystemRecords(int pageNum, int pageSize, String path) {
     var sourceSystemRecords = repository.getSourceSystems(pageNum, pageSize + 1);
     return wrapResponse(sourceSystemRecords, pageNum, pageSize, path);
+  }
+
+  public void deleteSourceSystem(String id) throws NotFoundException {
+    int result = repository.sourceSystemExists(id);
+    if (result > 0){
+      repository.deleteSourceSystem(id);
+    }
+    else throw new NotFoundException("Requested mapping does not exist");
   }
 
   private JsonApiWrapper wrapResponse(List<SourceSystemRecord> sourceSystemRecords, int pageNum,

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -35,9 +35,12 @@ public class SourceSystemService {
   }
 
   public SourceSystemRecord updateSourceSystem(String id, SourceSystem sourceSystem) throws NotFoundException{
-    var sourceSystemExists = repository.sourceSystemExists(id);
-    if (sourceSystemExists < 1){
+    var prevSourceSystem = repository.getActiveSourceSystem(id);
+    if (prevSourceSystem.isEmpty()){
       throw new NotFoundException("Could not update Source System " + id + ". Verify resource exists.");
+    }
+    if ((prevSourceSystem.get().sourceSystem()).equals(sourceSystem)){
+      return null;
     }
     var sourceSystemRecord = new SourceSystemRecord(id, Instant.now(), sourceSystem);
     repository.updateSourceSystem(sourceSystemRecord);
@@ -45,7 +48,7 @@ public class SourceSystemService {
   }
 
   public SourceSystemRecord getSourceSystemById(String id) {
-    return repository.getSourceSystemById(id);
+    return repository.getSourceSystem(id);
   }
 
   public JsonApiWrapper getSourceSystemRecords(int pageNum, int pageSize, String path) {
@@ -54,12 +57,12 @@ public class SourceSystemService {
   }
 
   public void deleteSourceSystem(String id) throws NotFoundException {
-    int result = repository.sourceSystemExists(id);
-    if (result > 0){
+    var result = repository.getActiveSourceSystem(id);
+    if (result.isPresent()){
       Instant deleted = Instant.now();
       repository.deleteSourceSystem(id, deleted);
     }
-    else throw new NotFoundException("Requested mapping does not exist");
+    else throw new NotFoundException("Requested source system"+id +" does not exist");
   }
 
   private JsonApiWrapper wrapResponse(List<SourceSystemRecord> sourceSystemRecords, int pageNum,

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -48,10 +48,6 @@ public class SourceSystemService {
     return wrapSingleResponse(id, sourceSystemRecord, path);
   }
 
-  public SourceSystemRecord getSourceSystemById(String id) {
-    return repository.getSourceSystem(id);
-  }
-
   public JsonApiWrapper getSourceSystemById(String id, String path) {
     var sourceSystemRecord = repository.getSourceSystem(id);
     return wrapSingleResponse(id, sourceSystemRecord, path);

--- a/src/test/java/eu/dissco/orchestration/backend/controller/MappingControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/MappingControllerTest.java
@@ -8,13 +8,10 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.SUFFIX;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMapping;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingRecord;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingRecordResponse;
-import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRecord;
-import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRecordResponse;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import eu.dissco.orchestration.backend.domain.MappingRecord;
-import eu.dissco.orchestration.backend.domain.SourceSystemRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.service.MappingService;
 import java.util.Collections;
@@ -75,7 +72,11 @@ class MappingControllerTest {
     givenAuthentication();
     var mapping = givenMapping();
     var expected = givenMappingRecord(HANDLE, 2);
-    given(service.updateMapping(HANDLE, mapping, OBJECT_CREATOR)).willReturn(expected);
+    try {
+      given(service.updateMapping(HANDLE, mapping, OBJECT_CREATOR)).willReturn(expected);
+    } catch (eu.dissco.orchestration.backend.exception.NotFoundException e) {
+      throw new RuntimeException(e);
+    }
 
     // Whan
     var result = controller.updateMapping(authentication, PREFIX, SUFFIX, mapping);

--- a/src/test/java/eu/dissco/orchestration/backend/controller/MappingControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/MappingControllerTest.java
@@ -101,6 +101,15 @@ class MappingControllerTest {
   }
 
   @Test
+  void testDeleteSourceSystem() throws Exception {
+    // When
+    var result = controller.deleteMapping(PREFIX, SUFFIX);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  @Test
   void testGetMappings(){
     int pageNum = 1;
     int pageSize = 10;

--- a/src/test/java/eu/dissco/orchestration/backend/controller/MappingControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/MappingControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.BDDMockito.given;
 
 import eu.dissco.orchestration.backend.domain.MappingRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.service.MappingService;
 import java.util.Collections;
 import java.util.List;
@@ -67,7 +68,7 @@ class MappingControllerTest {
   }
 
   @Test
-  void testUpdateMapping() {
+  void testUpdateMapping() throws NotFoundException {
     // Given
     givenAuthentication();
     var mapping = givenMapping();

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.Authentication;
 
 @ExtendWith(MockitoExtension.class)
 class SourceSystemControllerTest {
+
   @Mock
   private SourceSystemService service;
 
@@ -39,10 +40,12 @@ class SourceSystemControllerTest {
   private KeycloakPrincipal<KeycloakSecurityContext> principal;
 
   @BeforeEach
-  void setup(){controller = new SourceSystemController(service);}
+  void setup() {
+    controller = new SourceSystemController(service);
+  }
 
   @Test
-  void testCreateSourceSystem() throws Exception{
+  void testCreateSourceSystem() throws Exception {
     // Given
     var ssRecord = givenSourceSystemRecord();
     var ss = givenSourceSystem();
@@ -73,7 +76,7 @@ class SourceSystemControllerTest {
   }
 
   @Test
-  void testGetSourceSystemById(){
+  void testGetSourceSystemById() {
     // Given
     var id = HANDLE;
     var expected = givenSourceSystemRecord();
@@ -88,7 +91,7 @@ class SourceSystemControllerTest {
   }
 
   @Test
-  void testGetSourceSystems(){
+  void testGetSourceSystems() {
     // Given
     int pageNum = 1;
     int pageSize = 10;
@@ -109,7 +112,7 @@ class SourceSystemControllerTest {
   }
 
   @Test
-  void testGetSourceSystemsLastPage(){
+  void testGetSourceSystemsLastPage() {
     // Given
     int pageNum = 2;
     int pageSize = 10;
@@ -127,6 +130,15 @@ class SourceSystemControllerTest {
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(result.getBody()).isEqualTo(expected);
+  }
+
+  @Test
+  void testDeleteSourceSystem() throws Exception {
+    // When
+    var result = controller.deleteSourceSystem(PREFIX, SUFFIX);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
   private void givenAuthentication() {

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -60,7 +60,7 @@ class SourceSystemControllerTest {
   }
 
   @Test
-  void testUpdateSourceSystem() {
+  void testUpdateSourceSystem() throws Exception {
     // Given
     var ssRecord = givenSourceSystemRecord();
     var ss = givenSourceSystem();

--- a/src/test/java/eu/dissco/orchestration/backend/repository/MappingRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/MappingRepositoryIT.java
@@ -4,7 +4,6 @@ import static eu.dissco.orchestration.backend.database.jooq.Tables.NEW_MAPPING;
 import static eu.dissco.orchestration.backend.database.jooq.Tables.NEW_SOURCE_SYSTEM;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.CREATED;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.HANDLE;
-import static eu.dissco.orchestration.backend.testutils.TestUtils.HANDLE_ALT;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPER;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingRecord;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,20 +64,20 @@ class MappingRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetMappingOmitDeletedIsPresent() throws Exception{
+  void testGetActiveMappingIsPresent() throws Exception{
     // Given
     var mappingRecord = givenMappingRecord(HANDLE, 1);
     postMappingRecords(List.of(mappingRecord));
 
     // When
-    var result = repository.getMappingOmitDeleted(HANDLE);
+    var result = repository.getActiveMapping(HANDLE);
 
     // Then
-    assertThat(result).isEqualTo(mappingRecord);
+    assertThat(result).contains(mappingRecord);
   }
 
   @Test
-  void testGetMappingOmitDeletedNotPresent() throws Exception{
+  void testGetActiveMappingNotPresent() throws Exception{
     // Given
     var mappingRecord = givenMappingRecord(HANDLE, 1);
     postMappingRecords(List.of(mappingRecord));
@@ -88,10 +87,10 @@ class MappingRepositoryIT extends BaseRepositoryIT {
         .execute();
 
     // When
-    var result = repository.getMappingOmitDeleted(HANDLE);
+    var result = repository.getActiveMapping(HANDLE);
 
     // Then
-    assertThat(result).isNull();
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -126,19 +125,6 @@ class MappingRepositoryIT extends BaseRepositoryIT {
 
     //Then
     assertThat(result).hasSize(1);
-  }
-
-  @Test
-  void testMappingExists() throws Exception {
-    // Given
-    MappingRecord mapping = givenMappingRecord(HANDLE, 1);
-    postMappingRecords(List.of(mapping));
-
-    // When
-    var result = repository.mappingExists(HANDLE);
-
-    // Then
-    assertThat(result).isEqualTo(1);
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/repository/MappingRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/MappingRepositoryIT.java
@@ -4,6 +4,7 @@ import static eu.dissco.orchestration.backend.database.jooq.Tables.NEW_MAPPING;
 import static eu.dissco.orchestration.backend.database.jooq.Tables.NEW_SOURCE_SYSTEM;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.CREATED;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.HANDLE;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.HANDLE_ALT;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPER;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingRecord;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +62,36 @@ class MappingRepositoryIT extends BaseRepositoryIT {
 
     // Then
     assertThat(result).isEqualTo(mappingRecord);
+  }
+
+  @Test
+  void testGetMappingOmitDeletedIsPresent() throws Exception{
+    // Given
+    var mappingRecord = givenMappingRecord(HANDLE, 1);
+    postMappingRecords(List.of(mappingRecord));
+
+    // When
+    var result = repository.getMappingOmitDeleted(HANDLE);
+
+    // Then
+    assertThat(result).isEqualTo(mappingRecord);
+  }
+
+  @Test
+  void testGetMappingOmitDeletedNotPresent() throws Exception{
+    // Given
+    var mappingRecord = givenMappingRecord(HANDLE, 1);
+    postMappingRecords(List.of(mappingRecord));
+    context.update(NEW_MAPPING)
+        .set(NEW_MAPPING.DELETED, CREATED)
+        .where(NEW_MAPPING.ID.eq(HANDLE))
+        .execute();
+
+    // When
+    var result = repository.getMappingOmitDeleted(HANDLE);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -142,11 +142,11 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
     postSourceSystem(List.of(sourceSystemRecord));
 
     // When
-    repository.deleteSourceSystem(sourceSystemRecord.id());
-    var result = getAllSourceSystems();
+    repository.deleteSourceSystem(sourceSystemRecord.id(), CREATED);
+    var result = getDeleted(HANDLE);
 
     // Then
-    assertThat(result).isEmpty();
+    assertThat(result).isEqualTo(CREATED);
   }
 
   private SourceSystemRecord givenSourceSystemRecordWithId(String id){
@@ -163,10 +163,20 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
   }
 
   private List<SourceSystemRecord> getAllSourceSystems() {
-    return context.select(NEW_SOURCE_SYSTEM.ID, NEW_SOURCE_SYSTEM.CREATED, NEW_SOURCE_SYSTEM.NAME,
-            NEW_SOURCE_SYSTEM.ENDPOINT, NEW_SOURCE_SYSTEM.DESCRIPTION, NEW_SOURCE_SYSTEM.MAPPING_ID)
+    return context.select(NEW_SOURCE_SYSTEM.asterisk())
         .from(NEW_SOURCE_SYSTEM)
         .fetch(this::mapToSourceSystemRecord);
+  }
+
+  private Instant getDeleted(String id){
+    return context.select(NEW_SOURCE_SYSTEM.ID, NEW_SOURCE_SYSTEM.DELETED)
+        .from(NEW_SOURCE_SYSTEM)
+        .where(NEW_SOURCE_SYSTEM.ID.eq(id))
+        .fetchOne(this::getInstantDeleted);
+  }
+
+  private Instant getInstantDeleted(Record dbRecord){
+    return dbRecord.get(NEW_SOURCE_SYSTEM.DELETED);
   }
 
   private SourceSystemRecord mapToSourceSystemRecord(Record row) {

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -7,10 +7,12 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.HANDLE_ALT;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_DESCRIPTION;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SS_ENDPOINT;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_NAME;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingRecord;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import eu.dissco.orchestration.backend.domain.HandleType;
+import eu.dissco.orchestration.backend.domain.MappingRecord;
 import org.jooq.Record;
 
 import eu.dissco.orchestration.backend.domain.SourceSystem;
@@ -118,6 +120,33 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
     var result = repository.getSourceSystems(pageNum, pageSize);
 
     assertThat(result).hasSize(1);
+  }
+
+  @Test
+  void testMappingExists() throws Exception {
+    // Given
+    var sourceSystemRecord = givenSourceSystemRecord();
+    postSourceSystem(List.of(sourceSystemRecord));
+
+    // When
+    var result = repository.sourceSystemExists(sourceSystemRecord.id());
+
+    // Then
+    assertThat(result).isEqualTo(1);
+  }
+
+  @Test
+  void testDeleteMapping() throws Exception {
+    // Given
+    var sourceSystemRecord = givenSourceSystemRecord();
+    postSourceSystem(List.of(sourceSystemRecord));
+
+    // When
+    repository.deleteSourceSystem(sourceSystemRecord.id());
+    var result = getAllSourceSystems();
+
+    // Then
+    assertThat(result).isEmpty();
   }
 
   private SourceSystemRecord givenSourceSystemRecordWithId(String id){

--- a/src/test/java/eu/dissco/orchestration/backend/service/MappingServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/MappingServiceTest.java
@@ -10,6 +10,8 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMapping;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingRecord;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingRecordResponse;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
@@ -18,6 +20,7 @@ import eu.dissco.orchestration.backend.domain.HandleType;
 import eu.dissco.orchestration.backend.domain.Mapping;
 import eu.dissco.orchestration.backend.domain.MappingRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.repository.MappingRepository;
 import eu.dissco.orchestration.backend.repository.SourceSystemRepository;
 import java.time.Clock;
@@ -112,6 +115,24 @@ class MappingServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testDeleteMapping(){
+    // Given
+    given(repository.mappingExists(HANDLE)).willReturn(1);
+
+    // Then
+    assertDoesNotThrow(() -> service.deleteMapping(HANDLE));
+  }
+
+  @Test
+  void testDeleteSourceSystemNotFound(){
+    // Given
+    given(repository.mappingExists(HANDLE)).willReturn(0);
+
+    // Then
+    assertThrowsExactly(NotFoundException.class, () -> service.deleteMapping(HANDLE));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -8,6 +8,8 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSys
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRecord;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRecordResponse;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
@@ -15,6 +17,7 @@ import static org.mockito.Mockito.mockStatic;
 import eu.dissco.orchestration.backend.domain.HandleType;
 import eu.dissco.orchestration.backend.domain.SourceSystemRecord;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.repository.SourceSystemRepository;
 import java.time.Clock;
 import java.time.Instant;
@@ -122,6 +125,24 @@ class SourceSystemServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testDeleteSourceSystem(){
+    // Given
+    given(repository.sourceSystemExists(HANDLE)).willReturn(1);
+
+    // Then
+    assertDoesNotThrow(() -> service.deleteSourceSystem(HANDLE));
+  }
+
+  @Test
+  void testDeleteSourceSystemNotFound(){
+    // Given
+    given(repository.sourceSystemExists(HANDLE)).willReturn(0);
+
+    // Then
+    assertThrowsExactly(NotFoundException.class, () -> service.deleteSourceSystem(HANDLE));
   }
 
   private void initTime() {

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -67,12 +67,24 @@ class SourceSystemServiceTest {
   }
 
   @Test
-  void testUpdateSourceSystem(){
+  void testUpdateSourceSystemNotFound() {
+    // Given
+    var sourceSystem = givenSourceSystem();
+    given(repository.sourceSystemExists(HANDLE)).willReturn(0);
+
+    // Then
+    assertThrowsExactly(NotFoundException.class, () -> service.updateSourceSystem(HANDLE, sourceSystem));
+  }
+
+  @Test
+  void testUpdateSourceSystem() throws NotFoundException {
+    // Given
     var expected = givenSourceSystemRecord();
-    var ss = givenSourceSystem();
+    var sourceSystem = givenSourceSystem();
+    given(repository.sourceSystemExists(HANDLE)).willReturn(1);
 
     // When
-    var result = service.updateSourceSystem(HANDLE, ss);
+    var result = service.updateSourceSystem(HANDLE, sourceSystem);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -131,7 +131,6 @@ class SourceSystemServiceTest {
   void testDeleteSourceSystem(){
     // Given
     given(repository.sourceSystemExists(HANDLE)).willReturn(1);
-
     // Then
     assertDoesNotThrow(() -> service.deleteSourceSystem(HANDLE));
   }

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -114,8 +114,6 @@ class SourceSystemServiceTest {
     assertThat(result).isNull();
   }
 
-
-
   @Test
   void testGetSourceSystemById() throws Exception {
     // Given

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -80,6 +80,19 @@ class SourceSystemServiceTest {
   }
 
   @Test
+  void testUpdateSourceSystemNoChanges() throws Exception {
+    // Given
+    var sourceSystem = givenSourceSystem();
+    given(repository.getActiveSourceSystem(HANDLE)).willReturn(Optional.of(givenSourceSystemRecord()));
+
+    // When
+    var result = service.updateSourceSystem(HANDLE, sourceSystem);
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  @Test
   void testUpdateSourceSystem() throws NotFoundException {
     // Given
     var prevRecord = new SourceSystemRecord(


### PR DESCRIPTION
Added functionality to delete mappings and source systems from the database. Records are not removed from the DB; instead, their "deleted" field is updated. 

In paginated calls, we ignore deleted mappings/source systems, but we can still search for them by specific id

[Jira for this PR](https://naturalis.atlassian.net/browse/DD-323?atlOrigin=eyJpIjoiZDYxZGMwZjQ5MGE1NGM3ZGE4OTg1YWE2ZWU0Y2VhMTAiLCJwIjoiaiJ9)

Next: Tombstone PIDs of deleted mappings and source systems. [Jira ticket](https://naturalis.atlassian.net/browse/DD-323?atlOrigin=eyJpIjoiYmJiODE2YWExZTBhNGQwNDgyMzEzZGQ4YjQyODBhYWIiLCJwIjoiaiJ9)

