### PR TITLE
Hotfix/handle location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ target
 .idea
 
 src/main/resources/application.properties
+src/main/resources/jooq-configuration.xml
 
 

--- a/src/main/java/eu/dissco/orchestration/backend/service/HandleService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/HandleService.java
@@ -81,10 +81,10 @@ public class HandleService {
     var firstLocation = document.createElement("location");
     firstLocation.setAttribute("id", "0");
     if (type == HandleType.MAPPING) {
-      firstLocation.setAttribute("href", "https://sandbox.dissco.tech/api/v1/mappings/" + handle);
+      firstLocation.setAttribute("href", "https://sandbox.dissco.tech/orchestrator/mapping/" + handle);
     } else {
       firstLocation.setAttribute("href",
-          "https://sandbox.dissco.tech/api/v1/source-systems/" + handle);
+          "https://sandbox.dissco.tech/orchestrator/source-systems/" + handle);
     }
     firstLocation.setAttribute("weight", "0");
     locations.appendChild(firstLocation);

--- a/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MappingService.java
@@ -37,12 +37,13 @@ public class MappingService {
   }
   public JsonApiWrapper  updateMapping(String id, Mapping mapping, String userId, String path) throws NotFoundException{
     var currentVersion = repository.getActiveMapping(id);
-    if (!currentVersion.isPresent()){
+    if (currentVersion.isEmpty()){
       throw new NotFoundException("Requested mapping does not exist");
     }
     if (!currentVersion.get().mapping().equals(mapping)){
       var mappingRecord = new MappingRecord(id, currentVersion.get().version() + 1, Instant.now(), userId,
           mapping);
+      repository.deleteMapping(id, Instant.now());
       repository.createMapping(mappingRecord);
       return wrapSingleResponse(id, mappingRecord, path);
     } else {


### PR DESCRIPTION
1. Handle location changed from `...dissco.tech/api/v1/mapping/20...` to `dissco.tech/orchestrator/mapping/20...` (or source-system)
2. When updating a mapping record, we need to mark the previous as "deleted" so old versions don't come up in get requests (which filters on deleted==null)