### PR TITLE
Add a wait to give k8s time to process

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/properties/KubernetesProperties.java
+++ b/src/main/java/eu/dissco/orchestration/backend/properties/KubernetesProperties.java
@@ -3,6 +3,8 @@ package eu.dissco.orchestration.backend.properties;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
+
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -34,5 +36,8 @@ public class KubernetesProperties {
 
   @NotBlank
   private String kedaResource = "scaledobjects";
+
+  @Positive
+  private int kedaPatchWait = 500;
 
 }

--- a/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
@@ -292,6 +292,13 @@ public class MachineAnnotationServiceService {
       throw new KubernetesFailedException("Failed to remove keda from cluster");
     }
     try {
+      Thread.sleep(kubernetesProperties.getKedaPatchWait());
+    } catch (InterruptedException e) {
+      log.error("Application interrupted", e);
+      Thread.currentThread().interrupt();
+      throw new ProcessingFailedException("Application was interrupted during KEDA recreate", e);
+    }
+    try {
       deployKedaToCluster(masRecord);
     } catch (KubernetesFailedException e) {
       log.error(


### PR DESCRIPTION
I am pretty sure that the issue is caused by a race-condition. 
Locally the patch is successful, on the server often fails but sometimes works.
Probably the k8s call for deletion needs some time to be processed.
If we then immediately create a new one, the deletion call is not yet processed so it looks like it is already there.
This PR add a short (configurable) wait after the deletion request.
It should fix the issue. 