### PR TITLE
Update Cron image when property changed

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,5 @@
+# September 5 2024
+# Issues in base image in the libexpat library, needs to be fixed in a new version of the image
+CVE-2024-45490
+CVE-2024-45491
+CVE-2024-45492

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -70,6 +70,11 @@ public class SourceSystemService {
   private final Random random;
   private final FdoProperties fdoProperties;
 
+  @PostConstruct
+  public void setup() throws ApiException {
+    updateCronsToImageTag();
+  }
+
   private static String getSuffix(String sourceSystemId) {
     return sourceSystemId.substring(sourceSystemId.lastIndexOf('/') + 1).toLowerCase();
   }
@@ -106,11 +111,6 @@ public class SourceSystemService {
             currentSourceSystem.getOdsDataMappingID()) &&
         Objects.equals(sourceSystem.getLtcCollectionManagementSystem(),
             currentSourceSystem.getLtcCollectionManagementSystem());
-  }
-
-  @PostConstruct
-  public void setup() throws ApiException {
-    updateCronsToImageTag();
   }
 
   private void updateCronsToImageTag() throws ApiException {

--- a/src/main/resources/json-schema/source-system.json
+++ b/src/main/resources/json-schema/source-system.json
@@ -126,9 +126,9 @@
     "schema:dateCreated",
     "schema:dateModified",
     "schema:creator",
-    "schema:uri",
+    "schema:url",
     "ods:translatorType",
-    "ods:mappingID"
+    "ods:dataMappingID"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
Easier than expected.
Coupled this to the startup procedure, the @PostConstruct.
This means that if we cannot sync the cron's with the latest image, the app won't start.
I think that is fair as this would be a breaking issue.
If we continued otherwise we would get mixed ingestions which might result into unexpected issue (mixed data model versions for example).