### PR TITLE
Optionally trigger Job on update

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -56,6 +56,7 @@ public class SourceSystemController {
   @PatchMapping(value = "/{prefix}/{suffix}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> updateSourceSystem(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
+      @RequestParam(name = "trigger", defaultValue = "false") boolean trigger,
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
       throws IOException, NotFoundException, ProcessingFailedException {
     var sourceSystemRequest = getSourceSystemFromRequest(requestBody);
@@ -63,7 +64,7 @@ public class SourceSystemController {
     var userId = authentication.getName();
     log.info("Received update request for source system: {} from user: {}", id, userId);
     String path = appProperties.getBaseUrl() + servletRequest.getRequestURI();
-    var result = service.updateSourceSystem(id, sourceSystemRequest, userId, path);
+    var result = service.updateSourceSystem(id, sourceSystemRequest, userId, path, trigger);
     if (result == null) {
       return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     } else {

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -280,11 +280,14 @@ public class SourceSystemService {
         currentSourceSystem.getSchemaVersion() + 1, userId, id,
         currentSourceSystem.getSchemaDateCreated());
     if (isEquals(sourceSystem, currentSourceSystem)) {
+      log.info("Update request for source system: {} is identical to current version, no action taken",
+          id);
       return null;
     }
     repository.updateSourceSystem(sourceSystem);
     updateCronJob(sourceSystem, currentSourceSystem);
     if (trigger) {
+      log.info("Translator Job requested for updated source system: {}", id);
       triggerTranslatorForUpdatedSourceSystem(sourceSystem, currentSourceSystem);
     }
     publishUpdateEvent(sourceSystem, currentSourceSystem);

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -81,11 +81,11 @@ class SourceSystemControllerTest {
     var sourceSystem = givenSourceSystemRequestJson();
     givenAuthentication();
     given(service.updateSourceSystem(BARE_HANDLE, givenSourceSystemRequest(), "",
-        "null/source-system")).willReturn(
+        "null/source-system", true)).willReturn(
         givenSourceSystemSingleJsonApiWrapper());
 
     // When
-    var result = controller.updateSourceSystem(authentication, PREFIX, SUFFIX, sourceSystem,
+    var result = controller.updateSourceSystem(authentication, PREFIX, SUFFIX, true, sourceSystem,
         mockRequest);
 
     // Then
@@ -99,7 +99,7 @@ class SourceSystemControllerTest {
     givenAuthentication();
 
     // When
-    var result = controller.updateSourceSystem(authentication, PREFIX, SUFFIX, sourceSystem,
+    var result = controller.updateSourceSystem(authentication, PREFIX, SUFFIX, false, sourceSystem,
         mockRequest);
 
     // Then

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -357,6 +357,8 @@ class SourceSystemServiceTest {
     then(repository).should().updateSourceSystem(givenSourceSystem(2));
     if (!triggerTranslator) {
       then(batchV1Api).shouldHaveNoMoreInteractions();
+    } else {
+      then(batchV1Api).should().createNamespacedJob(eq(NAMESPACE), any(V1Job.class));
     }
     then(kafkaPublisherService).should()
         .publishUpdateEvent(MAPPER.valueToTree(givenSourceSystem(2)),


### PR DESCRIPTION
- `source-system/TEST/JH1-C37-E7F?trigger=true` The trigger=true part will now automatically trigger a TranslatorJob on the cluster. If we are unable to create Job we will rollback and publish an exception. This might indicate that there is something wrong and the CronJob also will crash when it starts creating jobs. 