### PR TITLE
Add maximum records to the k8s files

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -110,7 +110,9 @@ public class SourceSystemService {
         Objects.equals(sourceSystem.getOdsDataMappingID(),
             currentSourceSystem.getOdsDataMappingID()) &&
         Objects.equals(sourceSystem.getLtcCollectionManagementSystem(),
-            currentSourceSystem.getLtcCollectionManagementSystem());
+            currentSourceSystem.getLtcCollectionManagementSystem()) &&
+        Objects.equals(sourceSystem.getOdsMaximumRecords(),
+            currentSourceSystem.getOdsMaximumRecords());
   }
 
   private void updateCronsToImageTag() throws ApiException {
@@ -157,6 +159,7 @@ public class SourceSystemService {
         .withOdsDataMappingID(sourceSystemRequest.getOdsDataMappingID())
         .withOdsTranslatorType(
             OdsTranslatorType.fromValue(sourceSystemRequest.getOdsTranslatorType().value()))
+        .withOdsMaximumRecords(sourceSystemRequest.getOdsMaximumRecords())
         .withLtcCollectionManagementSystem(sourceSystemRequest.getLtcCollectionManagementSystem());
   }
 
@@ -428,6 +431,7 @@ public class SourceSystemService {
     var jobName = generateJobName(sourceSystem, isCronJob);
     map.put("image", jobProperties.getImage());
     map.put("sourceSystemId", removeProxy(sourceSystem.getId()));
+    map.put("maxItems", sourceSystem.getOdsMaximumRecords());
     map.put("jobName", jobName);
     map.put("namespace", jobProperties.getNamespace());
     map.put("containerName", jobName);

--- a/src/main/resources/json-schema/source-system-request.json
+++ b/src/main/resources/json-schema/source-system-request.json
@@ -34,6 +34,11 @@
         "Specify 7"
       ]
     },
+    "ods:maximumRecords": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "An optional parameter to limit the number of records to be ingested from this sourceSystem, it will pick the first X number of records it encounters. If left empty or absent it will process all records."
+    },
     "ods:translatorType": {
       "description": "The serialisation of the data the endpoint provides indicating what type of Translator is required",
       "enum": [

--- a/src/main/resources/json-schema/source-system.json
+++ b/src/main/resources/json-schema/source-system.json
@@ -29,7 +29,7 @@
     "ods:type": {
       "type": "string",
       "description": "The DOI to the FDO type of the object",
-      "pattern": "^https:\/\/doi\\.org\/[\\w\\.]+/[\\w\\.]+",
+      "pattern": "^https:\/\/doi\\.org/[\\w\\.]+/[\\w\\.]+",
       "examples": [
         "https://doi.org/10.15468/1a2b3c"
       ]
@@ -103,6 +103,11 @@
         "dwca",
         "biocase"
       ]
+    },
+    "ods:maximumRecords": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "An optional parameter to limit the number of records to be ingested from this sourceSystem, it will pick the first X number of records it encounters. If left empty or absent it will process all records."
     },
     "ods:dataMappingID": {
       "type": "string",

--- a/src/main/resources/templates/biocase-cron-job.ftl
+++ b/src/main/resources/templates/biocase-cron-job.ftl
@@ -26,8 +26,12 @@ spec:
               value: ${kafkaHost}
             - name: kafka.topic
               value: ${kafkaTopic}
-            - name: webclient.sourceSystemId
+            - name: application.sourceSystemId
               value: ${sourceSystemId}
+          <#if maxItems??>
+            - name: application.maxItems
+              value: ${maxItems}
+          </#if>
             - name: spring.datasource.url
               value: ${database_url}
             - name: spring.datasource.username

--- a/src/main/resources/templates/biocase-translator-job.ftl
+++ b/src/main/resources/templates/biocase-translator-job.ftl
@@ -24,8 +24,12 @@ spec:
               value: ${kafkaHost}
             - name: kafka.topic
               value: ${kafkaTopic}
-            - name: webclient.sourceSystemId
+            - name: application.sourceSystemId
               value: ${sourceSystemId}
+          <#if maxItems??>
+            - name: application.maxItems
+              value: ${maxItems}
+          </#if>
             - name: spring.datasource.url
               value: ${database_url}
             - name: spring.datasource.username

--- a/src/main/resources/templates/dwca-cron-job.ftl
+++ b/src/main/resources/templates/dwca-cron-job.ftl
@@ -30,8 +30,12 @@ spec:
               value: ${kafkaHost}
             - name: kafka.topic
               value: ${kafkaTopic}
-            - name: webclient.sourceSystemId
+            - name: application.sourceSystemId
               value: ${sourceSystemId}
+          <#if maxItems??>
+            - name: application.maxItems
+              value: ${maxItems}
+          </#if>
             - name: spring.datasource.url
               value: ${database_url}
             - name: spring.datasource.username

--- a/src/main/resources/templates/dwca-translator-job.ftl
+++ b/src/main/resources/templates/dwca-translator-job.ftl
@@ -28,8 +28,12 @@ spec:
               value: ${kafkaHost}
             - name: kafka.topic
               value: ${kafkaTopic}
-            - name: webclient.sourceSystemId
+            - name: application.sourceSystemId
               value: ${sourceSystemId}
+          <#if maxItems??>
+            - name: application.maxItems
+              value: ${maxItems}
+          </#if>
             - name: spring.datasource.url
               value: ${database_url}
             - name: spring.datasource.username

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -335,7 +335,7 @@ class SourceSystemServiceTest {
   @ValueSource(booleans = {true, false})
   void testUpdateSourceSystem(boolean triggerTranslator) throws Exception {
     var sourceSystem = givenSourceSystemRequest();
-    var prevSourceSystem = Optional.of(givenSourceSystem(OdsTranslatorType.DWCA));
+    var prevSourceSystem = Optional.of(givenSourceSystem(OdsTranslatorType.DWCA).withOdsMaximumRecords(25));
     given(fdoProperties.getSourceSystemType()).willReturn(SOURCE_SYSTEM_TYPE_DOI);
     var expected = givenSourceSystemSingleJsonApiWrapper(2);
     given(repository.getActiveSourceSystem(BARE_HANDLE)).willReturn(prevSourceSystem);


### PR DESCRIPTION
Impact of this is quiete low. MaxRecords added in openDS, added in request (which is one json we could add to openDS). Then added in the build of the SourceSystem from the request and added in the equals method.
In the freemarker template needed to add an if for when it is absent.
As it doesn't have impact on logic, only added it with an update test.

https://naturalis.atlassian.net/browse/DD-1334