### PR TITLE
Tombstone metadata

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,5 +1,3 @@
-# September 5 2024
-# Issues in base image in the libexpat library, needs to be fixed in a new version of the image
-CVE-2024-45490
-CVE-2024-45491
-CVE-2024-45492
+# September 16 2024
+# Issue in spring, spring boot needs to upgrade to 6.1.13
+CVE-2024-38816

--- a/src/main/java/eu/dissco/orchestration/backend/controller/DataMappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/DataMappingController.java
@@ -8,6 +8,7 @@ import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiListWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.orchestration.backend.exception.ForbiddenException;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.exception.ProcessingFailedException;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
@@ -44,7 +45,7 @@ public class DataMappingController {
   @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> createDataMapping(Authentication authentication,
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
-      throws JsonProcessingException, ProcessingFailedException {
+      throws JsonProcessingException, ProcessingFailedException, ForbiddenException {
     var dataMapping = getDataMappingRequestFromRequest(requestBody);
     var userId = getAgent(authentication).getId();
     log.info("Received create request for data mapping: {} from user: {}", dataMapping, userId);
@@ -57,7 +58,7 @@ public class DataMappingController {
   public ResponseEntity<JsonApiWrapper> updateDataMapping(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
-      throws JsonProcessingException, NotFoundException, ProcessingFailedException {
+      throws JsonProcessingException, NotFoundException, ProcessingFailedException, ForbiddenException {
     var dataMapping = getDataMappingRequestFromRequest(requestBody);
     var id = prefix + '/' + suffix;
     var userId = getAgent(authentication).getId();
@@ -75,7 +76,7 @@ public class DataMappingController {
   @DeleteMapping(value = "/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> tombstoneDataMapping(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
-      throws NotFoundException, ProcessingFailedException {
+      throws NotFoundException, ProcessingFailedException, ForbiddenException {
     String id = prefix + "/" + suffix;
     var agent = getAgent(authentication);
     log.info("Received delete request for mapping: {} from user: {}", id, agent.getId());

--- a/src/main/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceController.java
@@ -1,5 +1,7 @@
 package eu.dissco.orchestration.backend.controller;
 
+import static eu.dissco.orchestration.backend.utils.ControllerUtils.getAgent;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.domain.ObjectType;
@@ -45,7 +47,7 @@ public class MachineAnnotationServiceController {
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
       throws JsonProcessingException, ProcessingFailedException {
     var machineAnnotationService = getMachineAnnotation(requestBody);
-    var userId = authentication.getName();
+    var userId = getAgent(authentication).getId();
     log.info("Received create request for machine annotation service: {} from user: {}",
         machineAnnotationService, userId);
     String path = appProperties.getBaseUrl() + servletRequest.getRequestURI();
@@ -60,7 +62,7 @@ public class MachineAnnotationServiceController {
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
       throws JsonProcessingException, NotFoundException, ProcessingFailedException {
     var machineAnnotationService = getMachineAnnotation(requestBody);
-    var userId = authentication.getName();
+    var userId = getAgent(authentication).getId();
     var id = prefix + '/' + suffix;
     log.info("Received update request for machine annotation service: {} from user: {}", id,
         userId);
@@ -75,14 +77,14 @@ public class MachineAnnotationServiceController {
 
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @DeleteMapping(value = "/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<Void> deleteMachineAnnotationService(Authentication authentication,
+  public ResponseEntity<Void> tombstoneMachineAnnotationService(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
       throws NotFoundException, ProcessingFailedException {
     String id = prefix + "/" + suffix;
-    var userId = authentication.getName();
+    var agent = getAgent(authentication);
     log.info("Received delete request for machine annotation service: {} from user: {}", id,
-        userId);
-    service.deleteMachineAnnotationService(id, userId);
+        agent.getId());
+    service.tombstoneMachineAnnotationService(id, agent);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceController.java
@@ -8,6 +8,7 @@ import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiListWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.orchestration.backend.exception.ForbiddenException;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.exception.ProcessingFailedException;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
@@ -45,7 +46,7 @@ public class MachineAnnotationServiceController {
   public ResponseEntity<JsonApiWrapper> createMachineAnnotationService(
       Authentication authentication,
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
-      throws JsonProcessingException, ProcessingFailedException {
+      throws JsonProcessingException, ProcessingFailedException, ForbiddenException {
     var machineAnnotationService = getMachineAnnotation(requestBody);
     var userId = getAgent(authentication).getId();
     log.info("Received create request for machine annotation service: {} from user: {}",
@@ -60,7 +61,7 @@ public class MachineAnnotationServiceController {
       Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
-      throws JsonProcessingException, NotFoundException, ProcessingFailedException {
+      throws JsonProcessingException, NotFoundException, ProcessingFailedException, ForbiddenException {
     var machineAnnotationService = getMachineAnnotation(requestBody);
     var userId = getAgent(authentication).getId();
     var id = prefix + '/' + suffix;
@@ -79,7 +80,7 @@ public class MachineAnnotationServiceController {
   @DeleteMapping(value = "/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> tombstoneMachineAnnotationService(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
-      throws NotFoundException, ProcessingFailedException {
+      throws NotFoundException, ProcessingFailedException, ForbiddenException {
     String id = prefix + "/" + suffix;
     var agent = getAgent(authentication);
     log.info("Received delete request for machine annotation service: {} from user: {}", id,

--- a/src/main/java/eu/dissco/orchestration/backend/controller/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/RestResponseEntityExceptionHandler.java
@@ -1,6 +1,7 @@
 package eu.dissco.orchestration.backend.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.orchestration.backend.exception.ForbiddenException;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,5 +29,11 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<String> illegalArgumentException(IllegalArgumentException e) {
     return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+  }
+
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  @ExceptionHandler(ForbiddenException.class)
+  public ResponseEntity<String> forbiddenException(ForbiddenException e) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
   }
 }

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -8,6 +8,7 @@ import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiListWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.orchestration.backend.exception.ForbiddenException;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.exception.ProcessingFailedException;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
@@ -45,7 +46,7 @@ public class SourceSystemController {
   @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> createSourceSystem(Authentication authentication,
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
-      throws IOException, NotFoundException, ProcessingFailedException {
+      throws IOException, NotFoundException, ProcessingFailedException, ForbiddenException {
     var sourceSystemRequest = getSourceSystemFromRequest(requestBody);
     String path = appProperties.getBaseUrl() + servletRequest.getRequestURI();
     var userId = getAgent(authentication).getId();
@@ -60,7 +61,7 @@ public class SourceSystemController {
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       @RequestParam(name = "trigger", defaultValue = "false") boolean trigger,
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest servletRequest)
-      throws IOException, NotFoundException, ProcessingFailedException {
+      throws IOException, NotFoundException, ProcessingFailedException, ForbiddenException {
     var sourceSystemRequest = getSourceSystemFromRequest(requestBody);
     var id = prefix + '/' + suffix;
     var userId = getAgent(authentication).getId();
@@ -78,7 +79,7 @@ public class SourceSystemController {
   @DeleteMapping(value = "/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Void> tombstoneSourceSystem(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
-      throws NotFoundException, ProcessingFailedException {
+      throws NotFoundException, ProcessingFailedException, ForbiddenException {
     String id = prefix + "/" + suffix;
     var agent = getAgent(authentication);
     log.info("Received delete request for mapping: {} from user: {}", id, agent.getId());

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -1,5 +1,7 @@
 package eu.dissco.orchestration.backend.controller;
 
+import static eu.dissco.orchestration.backend.utils.ControllerUtils.getAgent;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.domain.ObjectType;
@@ -46,7 +48,7 @@ public class SourceSystemController {
       throws IOException, NotFoundException, ProcessingFailedException {
     var sourceSystemRequest = getSourceSystemFromRequest(requestBody);
     String path = appProperties.getBaseUrl() + servletRequest.getRequestURI();
-    var userId = authentication.getName();
+    var userId = getAgent(authentication).getId();
     log.info("Received create request for source system: {} from user: {}", sourceSystemRequest,
         userId);
     var result = service.createSourceSystem(sourceSystemRequest, userId, path);
@@ -61,7 +63,7 @@ public class SourceSystemController {
       throws IOException, NotFoundException, ProcessingFailedException {
     var sourceSystemRequest = getSourceSystemFromRequest(requestBody);
     var id = prefix + '/' + suffix;
-    var userId = authentication.getName();
+    var userId = getAgent(authentication).getId();
     log.info("Received update request for source system: {} from user: {}", id, userId);
     String path = appProperties.getBaseUrl() + servletRequest.getRequestURI();
     var result = service.updateSourceSystem(id, sourceSystemRequest, userId, path, trigger);
@@ -74,13 +76,13 @@ public class SourceSystemController {
 
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @DeleteMapping(value = "/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<Void> deleteSourceSystem(Authentication authentication,
+  public ResponseEntity<Void> tombstoneSourceSystem(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
       throws NotFoundException, ProcessingFailedException {
     String id = prefix + "/" + suffix;
-    var userId = authentication.getName();
-    log.info("Received delete request for mapping: {} from user: {}", id, userId);
-    service.deleteSourceSystem(id, userId);
+    var agent = getAgent(authentication);
+    log.info("Received delete request for mapping: {} from user: {}", id, agent.getId());
+    service.tombstoneSourceSystem(id, agent);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/exception/ForbiddenException.java
+++ b/src/main/java/eu/dissco/orchestration/backend/exception/ForbiddenException.java
@@ -1,0 +1,10 @@
+package eu.dissco.orchestration.backend.exception;
+
+public class ForbiddenException extends Exception {
+
+  public ForbiddenException(String message) {
+    super(message);
+  }
+
+
+}

--- a/src/main/java/eu/dissco/orchestration/backend/exception/PidAuthenticationException.java
+++ b/src/main/java/eu/dissco/orchestration/backend/exception/PidAuthenticationException.java
@@ -1,9 +1,0 @@
-package eu.dissco.orchestration.backend.exception;
-
-public class PidAuthenticationException extends Exception {
-
-  public PidAuthenticationException(String s) {
-    super(s);
-  }
-
-}

--- a/src/main/java/eu/dissco/orchestration/backend/exception/PidCreationException.java
+++ b/src/main/java/eu/dissco/orchestration/backend/exception/PidCreationException.java
@@ -1,9 +1,0 @@
-package eu.dissco.orchestration.backend.exception;
-
-public class PidCreationException extends Exception {
-
-  public PidCreationException(String s) {
-    super(s);
-  }
-
-}

--- a/src/main/java/eu/dissco/orchestration/backend/exception/PidException.java
+++ b/src/main/java/eu/dissco/orchestration/backend/exception/PidException.java
@@ -1,0 +1,9 @@
+package eu.dissco.orchestration.backend.exception;
+
+public class PidException extends Exception {
+
+  public PidException(String s) {
+    super(s);
+  }
+
+}

--- a/src/main/java/eu/dissco/orchestration/backend/repository/DataMappingRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/DataMappingRepository.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
 import eu.dissco.orchestration.backend.schema.DataMapping;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -86,10 +86,13 @@ public class DataMappingRepository {
         .fetch(this::mapToDataMapping);
   }
 
-  public void deleteDataMapping(String id, Date deleted) {
+  public void tombstoneDataMapping(DataMapping tombstoneDataMapping, Instant timestamp) {
     context.update(DATA_MAPPING)
-        .set(DATA_MAPPING.DATE_TOMBSTONED, deleted.toInstant())
-        .where(DATA_MAPPING.ID.eq(removeProxy(id)))
+        .set(DATA_MAPPING.DATE_TOMBSTONED, timestamp)
+        .set(DATA_MAPPING.DATE_MODIFIED, timestamp)
+        .set(DATA_MAPPING.VERSION, tombstoneDataMapping.getSchemaVersion())
+        .set(DATA_MAPPING.DATA, mapToJSONB(tombstoneDataMapping))
+        .where(DATA_MAPPING.ID.eq(removeProxy(tombstoneDataMapping.getId())))
         .execute();
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/repository/MachineAnnotationServiceRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/MachineAnnotationServiceRepository.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
 import eu.dissco.orchestration.backend.schema.Agent;
 import eu.dissco.orchestration.backend.schema.MachineAnnotationService;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -78,10 +78,13 @@ public class MachineAnnotationServiceRepository {
     }
   }
 
-  public void deleteMachineAnnotationService(String id, Date deleted) {
+  public void tombstoneMachineAnnotationService(MachineAnnotationService tombstoneMas, Instant timestamp) {
     context.update(MACHINE_ANNOTATION_SERVICE)
-        .set(MACHINE_ANNOTATION_SERVICE.DATE_TOMBSTONED, deleted.toInstant())
-        .where(MACHINE_ANNOTATION_SERVICE.ID.eq(removeProxy(id)))
+        .set(MACHINE_ANNOTATION_SERVICE.DATE_TOMBSTONED, timestamp)
+        .set(MACHINE_ANNOTATION_SERVICE.DATE_MODIFIED, timestamp)
+        .set(MACHINE_ANNOTATION_SERVICE.VERSION, tombstoneMas.getSchemaVersion())
+        .set(MACHINE_ANNOTATION_SERVICE.DATA, mapToJSONB(tombstoneMas))
+        .where(MACHINE_ANNOTATION_SERVICE.ID.eq(removeProxy(tombstoneMas.getId())))
         .execute();
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -79,10 +79,13 @@ public class SourceSystemRepository {
         .fetchOptional(this::mapToSourceSystem);
   }
 
-  public void deleteSourceSystem(String id, Date deleted) {
+  public void tombstoneSourceSystem(SourceSystem tombstoneSourceSystem, Instant timestamp) {
     context.update(SOURCE_SYSTEM)
-        .set(SOURCE_SYSTEM.DATE_TOMBSTONED, deleted.toInstant())
-        .where(SOURCE_SYSTEM.ID.eq(removeProxy(id)))
+        .set(SOURCE_SYSTEM.DATE_TOMBSTONED, timestamp)
+        .set(SOURCE_SYSTEM.DATE_MODIFIED, timestamp)
+        .set(SOURCE_SYSTEM.VERSION, tombstoneSourceSystem.getSchemaVersion())
+        .set(SOURCE_SYSTEM.DATA, mapToJSONB(tombstoneSourceSystem))
+        .where(SOURCE_SYSTEM.ID.eq(removeProxy(tombstoneSourceSystem.getId())))
         .execute();
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/FdoRecordService.java
@@ -43,8 +43,6 @@ public class FdoRecordService {
             .put("id", handle)
             .set("attributes", mapper.createObjectNode()
                 .put("tombstoneText", type.getFullName() + " tombstoned by user through the orchestration backend")));
-
-
   }
 
   public JsonNode buildRollbackCreateRequest(String handle) {

--- a/src/main/java/eu/dissco/orchestration/backend/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/FdoRecordService.java
@@ -36,6 +36,17 @@ public class FdoRecordService {
     return request;
   }
 
+  public JsonNode buildTombstoneRequest(ObjectType type, String handle) {
+    return mapper.createObjectNode()
+        .set("data", mapper.createObjectNode()
+            .put("type", getFdoType(type))
+            .put("id", handle)
+            .set("attributes", mapper.createObjectNode()
+                .put("tombstoneText", type.getFullName() + " tombstoned by user through the orchestration backend")));
+
+
+  }
+
   public JsonNode buildRollbackCreateRequest(String handle) {
     var dataNode = List.of(mapper.createObjectNode().put("id", removeProxy(handle)));
     ArrayNode dataArrayNode = mapper.valueToTree(dataNode);

--- a/src/main/java/eu/dissco/orchestration/backend/service/KafkaPublisherService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/KafkaPublisherService.java
@@ -16,18 +16,27 @@ public class KafkaPublisherService {
   private final KafkaTemplate<String, String> kafkaTemplate;
   private final ObjectMapper mapper;
   private final ProvenanceService provenanceService;
+  private static final String TOPIC = "createUpdateDeleteTopic";
 
   public void publishCreateEvent(JsonNode object)
       throws JsonProcessingException {
     var event = provenanceService.generateCreateEvent(object);
     log.info("Publishing new create message to queue: {}", event);
-    kafkaTemplate.send("createUpdateDeleteTopic", mapper.writeValueAsString(event));
+    kafkaTemplate.send(TOPIC, mapper.writeValueAsString(event));
   }
 
   public void publishUpdateEvent(JsonNode object, JsonNode currentObject)
       throws JsonProcessingException {
     var event = provenanceService.generateUpdateEvent(object, currentObject);
     log.info("Publishing new update message to queue: {}", event);
-    kafkaTemplate.send("createUpdateDeleteTopic", mapper.writeValueAsString(event));
+    kafkaTemplate.send(TOPIC, mapper.writeValueAsString(event));
   }
+
+  public void publishTombstoneEvent(JsonNode tombstoneObject, JsonNode currentObject)
+      throws JsonProcessingException {
+    var event = provenanceService.generateTombstoneEvent(tombstoneObject, currentObject);
+    log.info("Publishing new tombstone message to queue: {}", event);
+    kafkaTemplate.send(TOPIC, mapper.writeValueAsString(event));
+  }
+
 }

--- a/src/main/java/eu/dissco/orchestration/backend/service/ProvenanceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/ProvenanceService.java
@@ -86,13 +86,18 @@ public class ProvenanceService {
   }
 
   private static String getRdfsComment(ProvActivity.Type activityType) {
-    if (ProvActivity.Type.ODS_CREATE.equals(activityType)) {
-      return "Object newly created";
+    switch (activityType) {
+      case ODS_CREATE -> {
+        return "Object newly created";
+      }
+      case ODS_UPDATE -> {
+        return "Object updated";
+      }
+      case ODS_TOMBSTONE -> {
+        return "Object tombstoned";
+      }
     }
-    if (ProvActivity.Type.ODS_UPDATE.equals(activityType)) {
-      return "Object updated";
-    }
-    return "Object tombstoned";
+    return null;
   }
 
   private List<OdsChangeValue> mapJsonPatch(JsonNode jsonPatch) {

--- a/src/main/java/eu/dissco/orchestration/backend/service/ProvenanceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/ProvenanceService.java
@@ -35,6 +35,12 @@ public class ProvenanceService {
     return generateCreateUpdateTombStoneEvent(digitalObject, ProvActivity.Type.ODS_CREATE, null);
   }
 
+  public CreateUpdateTombstoneEvent generateTombstoneEvent(JsonNode tombstoneObject, JsonNode currentObject)
+      throws JsonProcessingException {
+    var patch = createJsonPatch(tombstoneObject, currentObject);
+    return generateCreateUpdateTombStoneEvent(tombstoneObject, ProvActivity.Type.ODS_TOMBSTONE, patch);
+  }
+
   private CreateUpdateTombstoneEvent generateCreateUpdateTombStoneEvent(
       JsonNode digitalObject, ProvActivity.Type activityType, JsonNode jsonPatch)
       throws JsonProcessingException {

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -14,8 +14,7 @@ import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiListWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
-import eu.dissco.orchestration.backend.exception.PidAuthenticationException;
-import eu.dissco.orchestration.backend.exception.PidCreationException;
+import eu.dissco.orchestration.backend.exception.PidException;
 import eu.dissco.orchestration.backend.exception.ProcessingFailedException;
 import eu.dissco.orchestration.backend.properties.FdoProperties;
 import eu.dissco.orchestration.backend.properties.TranslatorJobProperties;
@@ -183,7 +182,7 @@ public class SourceSystemService {
     );
     try {
       return handleComponent.postHandle(request);
-    } catch (PidAuthenticationException | PidCreationException e) {
+    } catch (PidException e) {
       throw new ProcessingFailedException(e.getMessage(), e);
     }
   }
@@ -247,7 +246,7 @@ public class SourceSystemService {
     var request = fdoRecordService.buildRollbackCreateRequest(sourceSystem.getId());
     try {
       handleComponent.rollbackHandleCreation(request);
-    } catch (PidAuthenticationException | PidCreationException e) {
+    } catch (PidException e) {
       log.error(
           "Unable to rollback handle creation for source system. Manually delete the following handle: {}. Cause of error: ",
           sourceSystem.getId(), e);
@@ -283,7 +282,8 @@ public class SourceSystemService {
         currentSourceSystem.getSchemaVersion() + 1, userId, id,
         currentSourceSystem.getSchemaDateCreated());
     if (isEquals(sourceSystem, currentSourceSystem)) {
-      log.info("Update request for source system: {} is identical to current version, no action taken",
+      log.info(
+          "Update request for source system: {} is identical to current version, no action taken",
           id);
       return null;
     }
@@ -366,27 +366,69 @@ public class SourceSystemService {
     );
   }
 
-  public void deleteSourceSystem(String id, String userId)
+  public void tombstoneSourceSystem(String id, Agent agent)
       throws NotFoundException, ProcessingFailedException {
     var result = repository.getActiveSourceSystem(id);
     if (result.isPresent()) {
       var sourceSystem = result.get();
-      sourceSystem.setOdsStatus(OdsStatus.ODS_TOMBSTONE);
-      sourceSystem.setOdsTombstoneMetadata(buildTombstoneMetadata(userId,
-          "Source System tombstoned by user through the orchestration backend."));
       try {
         batchV1Api.deleteNamespacedCronJob(generateJobName(result.get(), true),
             jobProperties.getNamespace()).execute();
       } catch (ApiException e) {
         throw new ProcessingFailedException("Failed to delete cronJob for source system: " + id, e);
       }
-      repository.deleteSourceSystem(id,
-          sourceSystem.getOdsTombstoneMetadata().getOdsTombstoneDate());
+      tombstoneHandle(sourceSystem);
+      var timestamp = Instant.now();
+      var tombstoneSourceSystem = buildTombstoneSourceSystem(sourceSystem, agent, timestamp);
+      repository.tombstoneSourceSystem(tombstoneSourceSystem, timestamp);
+      try {
+        kafkaPublisherService.publishTombstoneEvent(mapper.valueToTree(tombstoneSourceSystem), mapper.valueToTree(sourceSystem));
+      } catch (JsonProcessingException e) {
+        log.error("Unable to publish tombstone event to provenance service", e);
+        throw new ProcessingFailedException("Unable to publish tombstone event to provenance service", e);
+      }
       log.info("Delete request for source system: {} was successful", id);
     } else {
       throw new NotFoundException("Requested source system: " + id + " does not exist");
     }
   }
+
+  private void tombstoneHandle(SourceSystem sourceSystem) throws ProcessingFailedException {
+    var handle = removeProxy(sourceSystem.getId());
+    var request = fdoRecordService.buildTombstoneRequest(ObjectType.SOURCE_SYSTEM, handle);
+    try {
+      handleComponent.tombstoneHandle(request, handle);
+    } catch (PidException e){
+      log.error("Unable to tombstone handle {}", handle, e);
+      throw new ProcessingFailedException("Unable to tombstone handle", e);
+    }
+  }
+
+  private static SourceSystem buildTombstoneSourceSystem(SourceSystem sourceSystem, Agent tombstoningAgent,
+      Instant timestamp) {
+    return new SourceSystem()
+        .withId(sourceSystem.getId())
+        .withType(sourceSystem.getType())
+        .withOdsID(sourceSystem.getOdsID())
+        .withOdsType(sourceSystem.getOdsType())
+        .withOdsStatus(OdsStatus.ODS_TOMBSTONE)
+        .withSchemaVersion(sourceSystem.getSchemaVersion() + 1)
+        .withSchemaName(sourceSystem.getSchemaName())
+        .withSchemaDescription(sourceSystem.getSchemaDescription())
+        .withSchemaDateCreated(sourceSystem.getSchemaDateCreated())
+        .withSchemaDateModified(Date.from(timestamp))
+        .withSchemaCreator(sourceSystem.getSchemaCreator())
+        .withSchemaUrl(sourceSystem.getSchemaUrl())
+        .withLtcCollectionManagementSystem(sourceSystem.getLtcCollectionManagementSystem())
+        .withOdsTranslatorType(sourceSystem.getOdsTranslatorType())
+        .withOdsMaximumRecords(sourceSystem.getOdsMaximumRecords())
+        .withOdsDataMappingID(sourceSystem.getOdsDataMappingID())
+        .withOdsTombstoneMetadata(
+            buildTombstoneMetadata(tombstoningAgent,
+                "Source System tombstoned by user through the orchestration backend", timestamp));
+
+  }
+
 
   private JsonApiListWrapper wrapResponse(List<SourceSystem> sourceSystems, int pageNum,
       int pageSize, String path) {

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -377,7 +377,7 @@ public class SourceSystemService {
       } catch (ApiException e) {
         throw new ProcessingFailedException("Failed to delete cronJob for source system: " + id, e);
       }
-      tombstoneHandle(sourceSystem);
+      tombstoneHandle(id);
       var timestamp = Instant.now();
       var tombstoneSourceSystem = buildTombstoneSourceSystem(sourceSystem, agent, timestamp);
       repository.tombstoneSourceSystem(tombstoneSourceSystem, timestamp);
@@ -393,8 +393,7 @@ public class SourceSystemService {
     }
   }
 
-  private void tombstoneHandle(SourceSystem sourceSystem) throws ProcessingFailedException {
-    var handle = removeProxy(sourceSystem.getId());
+  private void tombstoneHandle(String handle) throws ProcessingFailedException {
     var request = fdoRecordService.buildTombstoneRequest(ObjectType.SOURCE_SYSTEM, handle);
     try {
       handleComponent.tombstoneHandle(request, handle);
@@ -426,9 +425,7 @@ public class SourceSystemService {
         .withOdsTombstoneMetadata(
             buildTombstoneMetadata(tombstoningAgent,
                 "Source System tombstoned by user through the orchestration backend", timestamp));
-
   }
-
 
   private JsonApiListWrapper wrapResponse(List<SourceSystem> sourceSystems, int pageNum,
       int pageSize, String path) {

--- a/src/main/java/eu/dissco/orchestration/backend/utils/ControllerUtils.java
+++ b/src/main/java/eu/dissco/orchestration/backend/utils/ControllerUtils.java
@@ -1,0 +1,38 @@
+package eu.dissco.orchestration.backend.utils;
+
+import eu.dissco.orchestration.backend.schema.Agent;
+import eu.dissco.orchestration.backend.schema.Agent.Type;
+import jakarta.ws.rs.ForbiddenException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+@Slf4j
+public class ControllerUtils {
+  private ControllerUtils(){}
+
+  public static Agent getAgent(Authentication authentication) throws ForbiddenException {
+    var claims = ((Jwt) authentication.getPrincipal()).getClaims();
+    if (claims.containsKey("orcid")) {
+      StringBuilder fullName = new StringBuilder();
+      if (claims.containsKey("given_name")){
+        fullName.append(claims.get("given_name"));
+      }
+      if (claims.containsKey("family_name")){
+        if (!fullName.isEmpty()) {
+          fullName.append(" ");
+        }
+        fullName.append(claims.get("family_name"));
+      }
+      return new Agent()
+          .withType(Type.SCHEMA_PERSON)
+          .withSchemaName(fullName.toString())
+          .withId((String) claims.get("orcid"));
+    } else {
+      log.error("Missing ORCID in token");
+      throw new ForbiddenException("Missing ORCID in token");
+    }
+  }
+
+
+}

--- a/src/main/java/eu/dissco/orchestration/backend/utils/ControllerUtils.java
+++ b/src/main/java/eu/dissco/orchestration/backend/utils/ControllerUtils.java
@@ -1,8 +1,8 @@
 package eu.dissco.orchestration.backend.utils;
 
+import eu.dissco.orchestration.backend.exception.ForbiddenException;
 import eu.dissco.orchestration.backend.schema.Agent;
 import eu.dissco.orchestration.backend.schema.Agent.Type;
-import jakarta.ws.rs.ForbiddenException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -30,7 +30,7 @@ public class ControllerUtils {
           .withId((String) claims.get("orcid"));
     } else {
       log.error("Missing ORCID in token");
-      throw new ForbiddenException("Missing ORCID in token");
+      throw new ForbiddenException("No ORCID provided");
     }
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/utils/TombstoneUtils.java
+++ b/src/main/java/eu/dissco/orchestration/backend/utils/TombstoneUtils.java
@@ -1,7 +1,6 @@
 package eu.dissco.orchestration.backend.utils;
 
 import eu.dissco.orchestration.backend.schema.Agent;
-import eu.dissco.orchestration.backend.schema.Agent.Type;
 import eu.dissco.orchestration.backend.schema.TombstoneMetadata;
 import java.time.Instant;
 import java.util.Date;
@@ -12,11 +11,11 @@ public class TombstoneUtils {
     // This is a utility class
   }
 
-  public static TombstoneMetadata buildTombstoneMetadata(String userID, String text) {
+  public static TombstoneMetadata buildTombstoneMetadata(Agent agent, String text, Instant timestamp) {
     return new TombstoneMetadata()
         .withType("ods:TombstoneMetadata")
-        .withOdsTombstonedByAgent(new Agent().withType(Type.SCHEMA_PERSON).withId(userID))
-        .withOdsTombstoneDate(Date.from(Instant.now()))
+        .withOdsTombstonedByAgent(agent)
+        .withOdsTombstoneDate(Date.from(timestamp))
         .withOdsTombstoneText(text);
   }
 }

--- a/src/main/java/eu/dissco/orchestration/backend/web/TokenAuthenticator.java
+++ b/src/main/java/eu/dissco/orchestration/backend/web/TokenAuthenticator.java
@@ -1,7 +1,6 @@
 package eu.dissco.orchestration.backend.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import eu.dissco.orchestration.backend.exception.PidAuthenticationException;
 import eu.dissco.orchestration.backend.exception.PidException;
 import eu.dissco.orchestration.backend.properties.TokenProperties;
 import java.nio.charset.StandardCharsets;
@@ -34,12 +33,12 @@ public class TokenAuthenticator {
         .acceptCharset(StandardCharsets.UTF_8)
         .retrieve()
         .onStatus(HttpStatus.UNAUTHORIZED::equals,
-            r -> Mono.error(new PidAuthenticationException("Service is unauthorized.")))
+            r -> Mono.error(new PidException("Service is unauthorized.")))
         .bodyToMono(JsonNode.class)
         .retryWhen(Retry.fixedDelay(3, Duration.ofSeconds(2))
             .filter(WebClientUtils::is5xxServerError)
             .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) ->
-                new PidAuthenticationException(
+                new PidException(
                     "External Service failed to process after max retries")
             ));
     try {

--- a/src/main/java/eu/dissco/orchestration/backend/web/TokenAuthenticator.java
+++ b/src/main/java/eu/dissco/orchestration/backend/web/TokenAuthenticator.java
@@ -2,6 +2,7 @@ package eu.dissco.orchestration.backend.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.orchestration.backend.exception.PidAuthenticationException;
+import eu.dissco.orchestration.backend.exception.PidException;
 import eu.dissco.orchestration.backend.properties.TokenProperties;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -26,7 +27,7 @@ public class TokenAuthenticator {
   @Qualifier("tokenClient")
   private final WebClient tokenClient;
 
-  public String getToken() throws PidAuthenticationException {
+  public String getToken() throws PidException {
     var response = tokenClient
         .post()
         .body(BodyInserters.fromFormData(properties.getFromFormData()))
@@ -48,19 +49,19 @@ public class TokenAuthenticator {
       Thread.currentThread().interrupt();
       log.info(
           "Unable to authenticate processing service with Keycloak. Verify client secret is up to-date");
-      throw new PidAuthenticationException(
+      throw new PidException(
           "Unable to authenticate processing service with Keycloak. More information: "
               + e.getMessage());
     }
   }
 
-  private String getToken(JsonNode tokenNode) throws PidAuthenticationException {
+  private String getToken(JsonNode tokenNode) throws PidException {
     if (tokenNode != null && tokenNode.get("access_token") != null) {
       return tokenNode.get("access_token").asText();
     }
     log.warn("Unexpected response from keycloak server. Unable to parse access_token: {}",
         tokenNode);
-    throw new PidAuthenticationException(
+    throw new PidException(
         "Unable to authenticate processing service with Keycloak. An error has occurred parsing keycloak response");
   }
 }

--- a/src/test/java/eu/dissco/orchestration/backend/controller/ControllerUtilsTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/ControllerUtilsTest.java
@@ -1,0 +1,95 @@
+package eu.dissco.orchestration.backend.controller;
+
+import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_CREATOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import eu.dissco.orchestration.backend.exception.ForbiddenException;
+import eu.dissco.orchestration.backend.schema.Agent;
+import eu.dissco.orchestration.backend.schema.Agent.Type;
+import eu.dissco.orchestration.backend.utils.ControllerUtils;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+@ExtendWith(MockitoExtension.class)
+class ControllerUtilsTest {
+
+  @Mock
+  private Authentication authentication;
+
+  @ParameterizedTest
+  @MethodSource("claimsAndNames")
+  void testGetAgentFullName(Map<String, Object> claims, Agent expected)
+      throws eu.dissco.orchestration.backend.exception.ForbiddenException {
+    // Given
+    givenAuthentication(claims);
+
+    // When
+    var agent = ControllerUtils.getAgent(authentication);
+
+    // Then
+    assertThat(agent).isEqualTo(expected);
+  }
+
+  @Test
+  void testNoOrcid() {
+    // Given
+    var claims = new HashMap<String, Object>(Map.of(
+        "family_name", "Attenborough",
+        "given_name", "David"));
+    givenAuthentication(claims);
+
+    // When / Then
+    assertThrows(ForbiddenException.class, () -> ControllerUtils.getAgent(authentication));
+  }
+
+
+  private static Stream<Arguments> claimsAndNames() {
+    return Stream.of(
+        Arguments.of(
+            new HashMap<String, Object>(Map.of(
+                "orcid", OBJECT_CREATOR,
+                "family_name", "Attenborough",
+                "given_name", "David")),
+            new Agent()
+                .withId(OBJECT_CREATOR)
+                .withSchemaName("David Attenborough")
+                .withType(Type.SCHEMA_PERSON)
+        ),
+        Arguments.of(new HashMap<String, Object>(Map.of(
+                "orcid", OBJECT_CREATOR,
+                "given_name", "David")),
+            new Agent()
+                .withId(OBJECT_CREATOR)
+                .withSchemaName("David")
+                .withType(Type.SCHEMA_PERSON)
+        ),
+        Arguments.of(new HashMap<String, Object>(Map.of(
+                "orcid", OBJECT_CREATOR,
+                "family_name", "Attenborough")),
+            new Agent()
+                .withId(OBJECT_CREATOR)
+                .withSchemaName("Attenborough")
+                .withType(Type.SCHEMA_PERSON)
+        ));
+  }
+
+
+  private void givenAuthentication(Map<String, Object> claims) {
+    var principal = mock(Jwt.class);
+    given(authentication.getPrincipal()).willReturn(principal);
+    given(principal.getClaims()).willReturn(claims);
+  }
+}

--- a/src/test/java/eu/dissco/orchestration/backend/controller/DataMappingControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/DataMappingControllerTest.java
@@ -8,6 +8,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPING_URI;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_CREATOR;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.PREFIX;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SUFFIX;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenClaims;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMapping;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMappingRequest;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMappingRequestJson;
@@ -17,6 +18,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSys
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
@@ -32,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 @ExtendWith(MockitoExtension.class)
 class DataMappingControllerTest {
@@ -116,7 +119,8 @@ class DataMappingControllerTest {
   @Test
   void testDeleteSourceSystem() throws Exception {
     // When
-    var result = controller.deleteDataMapping(authentication, PREFIX, SUFFIX);
+    givenAuthentication();
+    var result = controller.tombstoneDataMapping(authentication, PREFIX, SUFFIX);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
@@ -143,7 +147,8 @@ class DataMappingControllerTest {
   }
 
   private void givenAuthentication() {
-    given(authentication.getName()).willReturn(OBJECT_CREATOR);
+    var principal = mock(Jwt.class);
+    given(authentication.getPrincipal()).willReturn(principal);
+    given(principal.getClaims()).willReturn(givenClaims());
   }
-
 }

--- a/src/test/java/eu/dissco/orchestration/backend/controller/RestResponseEntityEntityExceptionHandlerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/RestResponseEntityEntityExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package eu.dissco.orchestration.backend.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import eu.dissco.orchestration.backend.exception.ForbiddenException;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,15 @@ class RestResponseEntityEntityExceptionHandlerTest {
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void testForbiddenException() {
+    // When
+    var result = exceptionHandler.forbiddenException(new ForbiddenException(""));
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 
 }

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -2,11 +2,13 @@ package eu.dissco.orchestration.backend.controller;
 
 import static eu.dissco.orchestration.backend.testutils.TestUtils.BARE_HANDLE;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPER;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_CREATOR;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.PREFIX;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SANDBOX_URI;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SUFFIX;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SYSTEM_PATH;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SYSTEM_URI;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenClaims;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMappingRequestJson;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystem;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRequest;
@@ -16,6 +18,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSys
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
@@ -30,8 +33,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 @ExtendWith(MockitoExtension.class)
 class SourceSystemControllerTest {
@@ -43,6 +46,7 @@ class SourceSystemControllerTest {
   @Mock
   private ApplicationProperties appProperties;
   private SourceSystemController controller;
+  @Mock
   private Authentication authentication;
 
   @BeforeEach
@@ -80,7 +84,7 @@ class SourceSystemControllerTest {
     // Given
     var sourceSystem = givenSourceSystemRequestJson();
     givenAuthentication();
-    given(service.updateSourceSystem(BARE_HANDLE, givenSourceSystemRequest(), "",
+    given(service.updateSourceSystem(BARE_HANDLE, givenSourceSystemRequest(), OBJECT_CREATOR,
         "null/source-system", true)).willReturn(
         givenSourceSystemSingleJsonApiWrapper());
 
@@ -155,19 +159,21 @@ class SourceSystemControllerTest {
   }
 
   @Test
-  void testDeleteSourceSystem() throws Exception {
+  void testTombstoneSourceSystem() throws Exception {
     // Given
     givenAuthentication();
 
     // When
-    var result = controller.deleteSourceSystem(authentication, PREFIX, SUFFIX);
+    var result = controller.tombstoneSourceSystem(authentication, PREFIX, SUFFIX);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
   private void givenAuthentication() {
-    authentication = new TestingAuthenticationToken(null, null);
+    var principal = mock(Jwt.class);
+    given(authentication.getPrincipal()).willReturn(principal);
+    given(principal.getClaims()).willReturn(givenClaims());
   }
 
 }

--- a/src/test/java/eu/dissco/orchestration/backend/repository/DataMappingRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/DataMappingRepositoryIT.java
@@ -11,11 +11,11 @@ import static eu.dissco.orchestration.backend.utils.HandleUtils.removeProxy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
 import eu.dissco.orchestration.backend.schema.DataMapping;
 import eu.dissco.orchestration.backend.schema.DataMapping.OdsStatus;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.jooq.JSONB;
@@ -156,15 +156,15 @@ class DataMappingRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testDeleteDataMapping() throws JsonProcessingException {
+  void testTombstoneDataMapping() throws JsonProcessingException {
     // Given
     var dataMapping = givenDataMapping(HANDLE, 1);
     dataMapping.setOdsStatus(OdsStatus.ODS_TOMBSTONE);
-    dataMapping.setOdsTombstoneMetadata(givenTombstoneMetadata());
+    dataMapping.setOdsTombstoneMetadata(givenTombstoneMetadata(ObjectType.DATA_MAPPING));
     postDataMappings(List.of(dataMapping));
 
     // When
-    repository.deleteDataMapping(HANDLE, Date.from(CREATED));
+    repository.tombstoneDataMapping(dataMapping, CREATED);
     var result = getDeleted(BARE_HANDLE);
 
     // Then

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -12,12 +12,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
+import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
 import eu.dissco.orchestration.backend.schema.SourceSystem.OdsStatus;
 import eu.dissco.orchestration.backend.schema.SourceSystem.OdsTranslatorType;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.jooq.JSONB;
@@ -120,15 +120,15 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testDeleteSourceSystem() throws JsonProcessingException {
+  void testTombstoneSourceSystem() throws JsonProcessingException {
     // Given
     var sourceSystem = givenSourceSystem();
     sourceSystem.withOdsStatus(OdsStatus.ODS_TOMBSTONE);
-    sourceSystem.withOdsTombstoneMetadata(givenTombstoneMetadata());
+    sourceSystem.withOdsTombstoneMetadata(givenTombstoneMetadata(ObjectType.SOURCE_SYSTEM));
     postSourceSystem(List.of(sourceSystem));
 
     // When
-    repository.deleteSourceSystem(sourceSystem.getId(), Date.from(CREATED));
+    repository.tombstoneSourceSystem(sourceSystem, CREATED);
     var result = getDeleted(BARE_HANDLE);
 
     // Then

--- a/src/test/java/eu/dissco/orchestration/backend/service/DataMappingServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/DataMappingServiceTest.java
@@ -8,16 +8,19 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPER;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPING_PATH;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_CREATOR;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SANDBOX_URI;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.UPDATED;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.flattenDataMapping;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenAgent;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMapping;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMappingRequest;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMappingSingleJsonApiWrapper;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMappingResponse;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstoneDataMapping;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
@@ -29,7 +32,7 @@ import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
-import eu.dissco.orchestration.backend.exception.PidCreationException;
+import eu.dissco.orchestration.backend.exception.PidException;
 import eu.dissco.orchestration.backend.exception.ProcessingFailedException;
 import eu.dissco.orchestration.backend.properties.FdoProperties;
 import eu.dissco.orchestration.backend.repository.DataMappingRepository;
@@ -67,6 +70,7 @@ class DataMappingServiceTest {
 
   private MockedStatic<Instant> mockedStatic;
   private MockedStatic<Clock> mockedClock;
+  Clock updatedClock = Clock.fixed(UPDATED, ZoneOffset.UTC);
 
   @BeforeEach
   void setup() {
@@ -125,7 +129,7 @@ class DataMappingServiceTest {
   void testCreateMasHandleFails() throws Exception {
     // Given
     var dataMapping = givenDataMappingRequest();
-    willThrow(PidCreationException.class).given(handleComponent).postHandle(any());
+    willThrow(PidException.class).given(handleComponent).postHandle(any());
 
     // Then
     assertThrowsExactly(ProcessingFailedException.class, () ->
@@ -140,7 +144,7 @@ class DataMappingServiceTest {
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     willThrow(JsonProcessingException.class).given(kafkaPublisherService)
         .publishCreateEvent(MAPPER.valueToTree(givenDataMapping(HANDLE, 1)));
-    willThrow(PidCreationException.class).given(handleComponent).rollbackHandleCreation(any());
+    willThrow(PidException.class).given(handleComponent).rollbackHandleCreation(any());
 
     // When
     assertThrowsExactly(ProcessingFailedException.class,
@@ -253,23 +257,30 @@ class DataMappingServiceTest {
   }
 
   @Test
-  void testDeleteDataMapping() {
+  void testTombstoneDataMapping() throws Exception {
     // Given
     given(repository.getActiveDataMapping(BARE_HANDLE)).willReturn(
         Optional.of(givenDataMapping(HANDLE, 1)));
+    mockedStatic.when(Instant::now).thenReturn(UPDATED);
+    mockedClock.when(Clock::systemUTC).thenReturn(updatedClock);
+
+    // When
+    service.tombstoneDataMapping(BARE_HANDLE, givenAgent());
 
     // Then
-    assertDoesNotThrow(() -> service.deleteDataMapping(BARE_HANDLE, OBJECT_CREATOR));
+    then(repository).should().tombstoneDataMapping(givenTombstoneDataMapping(), UPDATED);
+    then(handleComponent).should().tombstoneHandle(any(), eq(BARE_HANDLE));
+    then(kafkaPublisherService).should().publishTombstoneEvent(any(), any());
   }
 
   @Test
-  void testDeleteDataMappingNotFound() {
+  void testTombstoneDataMappingNotFound() {
     // Given
     given(repository.getActiveDataMapping(BARE_HANDLE)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NotFoundException.class,
-        () -> service.deleteDataMapping(BARE_HANDLE, OBJECT_CREATOR));
+        () -> service.tombstoneDataMapping(BARE_HANDLE, givenAgent()));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/service/DataMappingServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/DataMappingServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -280,6 +281,18 @@ class DataMappingServiceTest {
 
     // Then
     assertThrowsExactly(NotFoundException.class,
+        () -> service.tombstoneDataMapping(BARE_HANDLE, givenAgent()));
+  }
+
+  @Test
+  void testTombstoneDataMappingKafkaFailed() throws Exception {
+    // Given
+    given(repository.getActiveDataMapping(BARE_HANDLE)).willReturn(
+        Optional.of(givenDataMapping(HANDLE, 1)));
+    doThrow(JsonProcessingException.class).when(kafkaPublisherService).publishTombstoneEvent(any(), any());
+
+    // Then
+    assertThrowsExactly(ProcessingFailedException.class,
         () -> service.tombstoneDataMapping(BARE_HANDLE, givenAgent()));
   }
 

--- a/src/test/java/eu/dissco/orchestration/backend/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/FdoRecordServiceTest.java
@@ -1,5 +1,6 @@
 package eu.dissco.orchestration.backend.service;
 
+import static eu.dissco.orchestration.backend.testutils.TestUtils.BARE_HANDLE;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.HANDLE;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPER;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMappingRequest;
@@ -9,6 +10,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasReques
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenRollbackCreationRequest;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemHandleRequest;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRequest;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstoneRequestMas;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import eu.dissco.orchestration.backend.domain.ObjectType;
@@ -67,7 +69,18 @@ class FdoRecordServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
+  }
 
+  @Test
+  void testTombstonePid() throws Exception {
+    // given
+    var expected = givenTombstoneRequestMas();
+
+    // When
+    var result = builder.buildTombstoneRequest(ObjectType.MAS, BARE_HANDLE);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
   }
 
 }

--- a/src/test/java/eu/dissco/orchestration/backend/service/KafkaPublisherServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/KafkaPublisherServiceTest.java
@@ -53,5 +53,15 @@ class KafkaPublisherServiceTest {
     then(kafkaTemplate).should().send(eq("createUpdateDeleteTopic"), anyString());
   }
 
+  @Test
+  void testPublishTombstoneEvent() throws Exception {
+    // Given
 
+    // When
+    service.publishTombstoneEvent(MAPPER.valueToTree(TestUtils.givenTombstoneMas()),
+        MAPPER.valueToTree(TestUtils.givenMas()));
+
+    // Then
+    then(kafkaTemplate).should().send(eq("createUpdateDeleteTopic"), anyString());
+  }
 }

--- a/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
@@ -9,15 +9,17 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.MAS_TYPE_DOI;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_CREATOR;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.SUFFIX;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.TTL;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.UPDATED;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.flattenMas;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenAgent;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMas;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasEnvironment;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasRequest;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasResponse;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasSecrets;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasSingleJsonApiWrapper;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstoneMas;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -35,7 +37,7 @@ import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiWrapper;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
-import eu.dissco.orchestration.backend.exception.PidCreationException;
+import eu.dissco.orchestration.backend.exception.PidException;
 import eu.dissco.orchestration.backend.exception.ProcessingFailedException;
 import eu.dissco.orchestration.backend.properties.FdoProperties;
 import eu.dissco.orchestration.backend.properties.KubernetesProperties;
@@ -63,7 +65,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -93,7 +94,6 @@ class MachineAnnotationServiceServiceTest {
   private HandleComponent handleComponent;
   @Mock
   private FdoRecordService fdoRecordService;
-
   @Mock
   private MachineAnnotationServiceProperties properties;
   @Mock
@@ -106,6 +106,8 @@ class MachineAnnotationServiceServiceTest {
 
   private MockedStatic<Instant> mockedStatic;
   private MockedStatic<Clock> mockedClock;
+
+  Clock updatedClock = Clock.fixed(UPDATED, ZoneOffset.UTC);
 
   @BeforeEach
   void setup() throws IOException {
@@ -222,7 +224,7 @@ class MachineAnnotationServiceServiceTest {
   void testCreateMasHandleFails() throws Exception {
     // Given
     var mas = givenMasRequest();
-    willThrow(PidCreationException.class).given(handleComponent).postHandle(any());
+    willThrow(PidException.class).given(handleComponent).postHandle(any());
 
     // Then
     assertThrowsExactly(ProcessingFailedException.class, () ->
@@ -344,7 +346,7 @@ class MachineAnnotationServiceServiceTest {
     given(properties.getNamespace()).willReturn("namespace");
     willThrow(JsonProcessingException.class).given(kafkaPublisherService)
         .publishCreateEvent(MAPPER.valueToTree(givenMas()));
-    willThrow(PidCreationException.class).given(handleComponent).rollbackHandleCreation(any());
+    willThrow(PidException.class).given(handleComponent).rollbackHandleCreation(any());
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
     given(appsV1Api.createNamespacedDeployment(eq("namespace"), any(V1Deployment.class)))
         .willReturn(createDeploy);
@@ -605,33 +607,18 @@ class MachineAnnotationServiceServiceTest {
   }
 
   @Test
-  void testDeletedMas() {
-    // Given
-    given(repository.getActiveMachineAnnotationService(HANDLE)).willReturn(
-        Optional.of(givenMas()));
-    var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
-    given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        null)).willReturn(deleteDeploy);
-    var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", null,
-        "scaledobjects", "gw0-pop-xsl-scaled-object")).willReturn(deleteCustom);
-
-    // When / Then
-    assertDoesNotThrow(() -> service.deleteMachineAnnotationService(HANDLE, OBJECT_CREATOR));
-  }
-
-  @Test
   void testDeletedMasNotFound() {
     // Given
     given(repository.getActiveMachineAnnotationService(HANDLE)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NotFoundException.class,
-        () -> service.deleteMachineAnnotationService(HANDLE, OBJECT_CREATOR));
+        () -> service.tombstoneMachineAnnotationService(HANDLE, givenAgent()));
   }
 
   @Test
-  void testDeleteMas() throws NotFoundException, ProcessingFailedException {
+  void testTombstoneMas()
+      throws Exception {
     // Given
     given(repository.getActiveMachineAnnotationService(HANDLE)).willReturn(
         Optional.of(givenMas()));
@@ -642,22 +629,25 @@ class MachineAnnotationServiceServiceTest {
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
     given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", "namespace",
         "scaledobjects", "gw0-pop-xsl-scaled-object")).willReturn(deleteCustom);
+    mockedStatic.when(Instant::now).thenReturn(UPDATED);
+    mockedClock.when(Clock::systemUTC).thenReturn(updatedClock);
 
     // When
-    service.deleteMachineAnnotationService(HANDLE, OBJECT_CREATOR);
+    service.tombstoneMachineAnnotationService(HANDLE, givenAgent());
 
     // Then
-    then(repository).should().deleteMachineAnnotationService(HANDLE, Date.from(Instant.now()));
+    then(repository).should().tombstoneMachineAnnotationService(givenTombstoneMas(), Instant.now());
     then(appsV1Api).should()
         .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq("namespace"));
     then(customObjectsApi).should()
         .deleteNamespacedCustomObject(anyString(), anyString(), eq("namespace"), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
-    then(kafkaPublisherService).shouldHaveNoInteractions();
+    then(handleComponent).should().tombstoneHandle(any(), eq(BARE_HANDLE));
+    then(kafkaPublisherService).should().publishTombstoneEvent(any(), any());
   }
 
   @Test
-  void testDeleteDeployFails() throws ApiException {
+  void testDeleteDeployFails() throws ApiException, JsonProcessingException {
     // Given
     given(repository.getActiveMachineAnnotationService(HANDLE)).willReturn(
         Optional.of(givenMas()));
@@ -666,21 +656,23 @@ class MachineAnnotationServiceServiceTest {
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
         "namespace")).willReturn(deleteDeploy);
     given(deleteDeploy.execute()).willThrow(new ApiException());
+    mockedStatic.when(Instant::now).thenReturn(UPDATED);
+    mockedClock.when(Clock::systemUTC).thenReturn(updatedClock);
 
     // When
     assertThrowsExactly(ProcessingFailedException.class,
-        () -> service.deleteMachineAnnotationService(HANDLE, OBJECT_CREATOR));
+        () -> service.tombstoneMachineAnnotationService(HANDLE, givenAgent()));
 
     // Then
-    then(repository).should().deleteMachineAnnotationService(HANDLE, Date.from(Instant.now()));
+    then(repository).should().tombstoneMachineAnnotationService(givenTombstoneMas(), Instant.now());
     then(repository).should()
         .createMachineAnnotationService(any(MachineAnnotationService.class));
     then(customObjectsApi).shouldHaveNoInteractions();
-    then(kafkaPublisherService).shouldHaveNoInteractions();
+    then(kafkaPublisherService).should().publishTombstoneEvent(any(), any());
   }
 
   @Test
-  void testDeleteKedaFails() throws ApiException {
+  void testDeleteKedaFails() throws ApiException, JsonProcessingException {
     // Given
     given(repository.getActiveMachineAnnotationService(HANDLE)).willReturn(
         Optional.of(givenMas()));
@@ -698,20 +690,22 @@ class MachineAnnotationServiceServiceTest {
     given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", "namespace",
         "scaledobjects", "gw0-pop-xsl-scaled-object")).willReturn(deleteCustom);
     given(deleteCustom.execute()).willThrow(new ApiException());
+    mockedStatic.when(Instant::now).thenReturn(UPDATED);
+    mockedClock.when(Clock::systemUTC).thenReturn(updatedClock);
 
     // When
     assertThrowsExactly(ProcessingFailedException.class,
-        () -> service.deleteMachineAnnotationService(HANDLE, OBJECT_CREATOR));
+        () -> service.tombstoneMachineAnnotationService(HANDLE, givenAgent()));
 
     // Then
-    then(repository).should().deleteMachineAnnotationService(HANDLE, Date.from(Instant.now()));
+    then(repository).should().tombstoneMachineAnnotationService(givenTombstoneMas(), UPDATED);
     then(repository).should()
         .createMachineAnnotationService(any(MachineAnnotationService.class));
     then(appsV1Api).should().deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"),
         eq("namespace"));
     then(appsV1Api).should()
         .createNamespacedDeployment(eq("namespace"), any(V1Deployment.class));
-    then(kafkaPublisherService).shouldHaveNoInteractions();
+    then(kafkaPublisherService).should().publishTombstoneEvent(any(), any());
   }
 
   private static Stream<Arguments> masKeys() {

--- a/src/test/java/eu/dissco/orchestration/backend/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/ProvenanceServiceTest.java
@@ -6,15 +6,26 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.HANDLE;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPER;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.OBJECT_CREATOR;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.TTL;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.UPDATED;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMapping;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMas;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystem;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstoneDataMapping;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstoneMas;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstoneMetadata;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstoneSourceSystem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
 import eu.dissco.orchestration.backend.schema.Agent;
 import eu.dissco.orchestration.backend.schema.Agent.Type;
+import eu.dissco.orchestration.backend.schema.MachineAnnotationService.OdsStatus;
 import eu.dissco.orchestration.backend.schema.OdsChangeValue;
+import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +70,7 @@ class ProvenanceServiceTest {
     // Then
     assertThat(event.getOdsID()).isEqualTo(HANDLE + "/" + "1");
     assertThat(event.getProvActivity().getOdsChangeValue()).isNull();
+    assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Object newly created");
     assertThat(event.getProvEntity().getProvValue()).isNotNull();
     assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
   }
@@ -77,20 +89,92 @@ class ProvenanceServiceTest {
 
     // Then
     assertThat(event.getOdsID()).isEqualTo(HANDLE + "/" + "2");
-    assertThat(event.getProvActivity().getOdsChangeValue()).isEqualTo(givenChangeValue());
+    assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Object updated");
+    assertThat(event.getProvActivity().getOdsChangeValue()).isEqualTo(givenChangeValueUpdate());
     assertThat(event.getProvEntity().getProvValue()).isNotNull();
     assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
   }
 
-  List<OdsChangeValue> givenChangeValue() {
-    return List.of(new OdsChangeValue()
-            .withAdditionalProperty("op", "replace")
-            .withAdditionalProperty("path", "/schema:version")
-            .withAdditionalProperty("value", 2),
-        new OdsChangeValue()
-            .withAdditionalProperty("op", "replace")
-            .withAdditionalProperty("path", "/schema:name")
-            .withAdditionalProperty("value", "A Machine Annotation Service")
+  @Test
+  void testGenerateTombstoneEventMas() throws Exception {
+    // Given
+    given(properties.getName()).willReturn(APP_NAME);
+    given(properties.getPid()).willReturn(APP_HANDLE);
+    var originalMas = MAPPER.valueToTree(givenMas());
+    var tombstoneMas = MAPPER.valueToTree(givenTombstoneMas());
+
+    // When
+    var event = service.generateTombstoneEvent(tombstoneMas, originalMas);
+
+    // Then
+    assertThat(event.getOdsID()).isEqualTo(HANDLE + "/" + "2");
+    assertThat(event.getProvActivity().getOdsChangeValue()).isEqualTo(
+        givenChangeValueTombstone(ObjectType.MAS));
+    assertThat(event.getProvEntity().getProvValue()).isNotNull();
+    assertThat(event.getProvActivity().getRdfsComment()).isEqualTo("Object tombstoned");
+    assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
+  }
+
+  @Test
+  void testGenerateTombstoneEventSourceSystem() throws Exception {
+    // Given
+    given(properties.getName()).willReturn(APP_NAME);
+    given(properties.getPid()).willReturn(APP_HANDLE);
+    var originalSourceSystem = MAPPER.valueToTree(givenSourceSystem());
+    var tombstoneSourceSystem = MAPPER.valueToTree(givenTombstoneSourceSystem());
+
+    // When
+    var event = service.generateTombstoneEvent(tombstoneSourceSystem, originalSourceSystem);
+
+    // Then
+    assertThat(event.getOdsID()).isEqualTo(HANDLE + "/" + "2");
+    assertThat(event.getProvActivity().getOdsChangeValue()).hasSameElementsAs(
+        givenChangeValueTombstone(ObjectType.SOURCE_SYSTEM));
+    assertThat(event.getProvEntity().getProvValue()).isNotNull();
+    assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
+  }
+
+  @Test
+  void testGenerateTombstoneEventDataMapping() throws Exception {
+    // Given
+    given(properties.getName()).willReturn(APP_NAME);
+    given(properties.getPid()).willReturn(APP_HANDLE);
+    var originalDataMapping = MAPPER.valueToTree(givenDataMapping());
+    var tombstoneDataMapping = MAPPER.valueToTree(givenTombstoneDataMapping());
+
+    // When
+    var event = service.generateTombstoneEvent(tombstoneDataMapping, originalDataMapping);
+
+    // Then
+    assertThat(event.getOdsID()).isEqualTo(HANDLE + "/" + "2");
+    assertThat(event.getProvActivity().getOdsChangeValue()).hasSameElementsAs(
+        givenChangeValueTombstone(ObjectType.DATA_MAPPING));
+    assertThat(event.getProvEntity().getProvValue()).isNotNull();
+    assertThat(event.getOdsHasProvAgent()).isEqualTo(givenExpectedAgents());
+  }
+
+
+  private static List<OdsChangeValue> givenChangeValueTombstone(ObjectType objectType) {
+    return List.of(
+        givenOdsChangeValue("add", "/ods:TombstoneMetadata", givenTombstoneMetadata(objectType)),
+        givenOdsChangeValue("replace", "/ods:status", OdsStatus.ODS_TOMBSTONE),
+        givenOdsChangeValue("replace", "/schema:version", 2),
+        givenOdsChangeValue("replace", "/schema:dateModified", Date.from(UPDATED))
     );
+  }
+
+  private static List<OdsChangeValue> givenChangeValueUpdate() {
+    return List.of(
+        givenOdsChangeValue("replace", "/schema:version", 2),
+        givenOdsChangeValue("replace", "/schema:name", "A Machine Annotation Service")
+    );
+  }
+
+  private static OdsChangeValue givenOdsChangeValue(String op, String path, Object value) {
+    return new OdsChangeValue()
+        .withAdditionalProperty("op", op)
+        .withAdditionalProperty("path", path)
+        .withAdditionalProperty("value", MAPPER.convertValue(value, new TypeReference<>() {
+        }));
   }
 }

--- a/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
+++ b/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
@@ -1,5 +1,6 @@
 package eu.dissco.orchestration.backend.testutils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.domain.ObjectType;
@@ -65,7 +66,6 @@ public class TestUtils {
   public static final String SOURCE_SYSTEM_TYPE_DOI = "https://hdl.handle.net/21.T11148/417a4f472f60f7974c12";
   public static final String DATA_MAPPING_TYPE_DOI = "https://hdl.handle.net/21.T11148/ce794a6f4df42eb7e77e";
   public static final String MAS_TYPE_DOI = "https://hdl.handle.net/21.T11148/22e71a0015cbcfba8ffa";
-
 
   private TestUtils() {
     throw new IllegalStateException("Utility class");
@@ -413,6 +413,21 @@ public class TestUtils {
           "data":
             [{"id":"20.5000.1025/GW0-POP-XSL"}]
         }""");
+  }
+
+  public static JsonNode givenTombstoneRequestMas() throws JsonProcessingException {
+    return MAPPER.readTree("""
+        {
+          "data": {
+            "id": "20.5000.1025/GW0-POP-XSL",
+            "type": "https://doi.org/21.T11148/22e71a0015cbcfba8ffa",
+            "attributes": {
+              "tombstoneText": "ods:MachineAnnotationService tombstoned by user through the orchestration backend"
+            }
+          }
+        }
+        """);
+
   }
 
   public static TombstoneMetadata givenTombstoneMetadata(ObjectType objectType) {

--- a/src/test/java/eu/dissco/orchestration/backend/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/web/HandleComponentTest.java
@@ -9,8 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import eu.dissco.orchestration.backend.exception.PidAuthenticationException;
-import eu.dissco.orchestration.backend.exception.PidCreationException;
+import eu.dissco.orchestration.backend.exception.PidException;
 import java.io.IOException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -88,7 +87,7 @@ class HandleComponentTest {
         .addHeader("Content-Type", "application/json"));
 
     // Then
-    assertThrows(PidAuthenticationException.class, () -> handleComponent.postHandle(requestBody));
+    assertThrows(PidException.class, () -> handleComponent.postHandle(requestBody));
   }
 
   @Test
@@ -100,7 +99,7 @@ class HandleComponentTest {
         .addHeader("Content-Type", "application/json"));
 
     // Then
-    assertThrows(PidCreationException.class, () -> handleComponent.postHandle(requestBody));
+    assertThrows(PidException.class, () -> handleComponent.postHandle(requestBody));
   }
 
   @Test
@@ -136,7 +135,7 @@ class HandleComponentTest {
     Thread.currentThread().interrupt();
 
     // When
-    var response = assertThrows(PidCreationException.class,
+    var response = assertThrows(PidException.class,
         () -> handleComponent.postHandle(requestBody));
 
     // Then
@@ -156,7 +155,7 @@ class HandleComponentTest {
     mockHandleServer.enqueue(new MockResponse().setResponseCode(501));
 
     // Then
-    assertThrows(PidCreationException.class, () -> handleComponent.postHandle(requestBody));
+    assertThrows(PidException.class, () -> handleComponent.postHandle(requestBody));
     assertThat(mockHandleServer.getRequestCount() - requestCount).isEqualTo(4);
   }
 
@@ -179,7 +178,7 @@ class HandleComponentTest {
         .setBody(MAPPER.writeValueAsString(responseBody))
         .addHeader("Content-Type", "application/json"));
     // Then
-    assertThrows(PidCreationException.class, () -> handleComponent.postHandle(requestBody));
+    assertThrows(PidException.class, () -> handleComponent.postHandle(requestBody));
   }
 
   @Test
@@ -192,7 +191,7 @@ class HandleComponentTest {
         .setBody(MAPPER.writeValueAsString(responseBody))
         .addHeader("Content-Type", "application/json"));
     // Then
-    assertThrows(PidCreationException.class, () -> handleComponent.postHandle(requestBody));
+    assertThrows(PidException.class, () -> handleComponent.postHandle(requestBody));
   }
 
   private JsonNode givenHandleApiResponse() throws Exception {

--- a/src/test/java/eu/dissco/orchestration/backend/web/TokenAuthenticatorTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/web/TokenAuthenticatorTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import eu.dissco.orchestration.backend.exception.PidAuthenticationException;
+import eu.dissco.orchestration.backend.exception.PidException;
 import eu.dissco.orchestration.backend.properties.TokenProperties;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -98,7 +98,7 @@ class TokenAuthenticatorTest {
         .addHeader("Content-Type", "application/json"));
 
     // Then
-    assertThrows(PidAuthenticationException.class, () -> authenticator.getToken());
+    assertThrows(PidException.class, () -> authenticator.getToken());
   }
 
   @Test
@@ -133,7 +133,7 @@ class TokenAuthenticatorTest {
     mockTokenServer.enqueue(new MockResponse().setResponseCode(501));
 
     // Then
-    assertThrows(PidAuthenticationException.class, () -> authenticator.getToken());
+    assertThrows(PidException.class, () -> authenticator.getToken());
     assertThat(mockTokenServer.getRequestCount() - requestCount).isEqualTo(4);
   }
 
@@ -145,7 +145,7 @@ class TokenAuthenticatorTest {
         .addHeader("Content-Type", "application/json"));
 
     // When
-    assertThrows(PidAuthenticationException.class, () -> authenticator.getToken());
+    assertThrows(PidException.class, () -> authenticator.getToken());
   }
 
   @Test
@@ -157,7 +157,7 @@ class TokenAuthenticatorTest {
         .setBody("{}"));
 
     // When
-    assertThrows(PidAuthenticationException.class, () -> authenticator.getToken());
+    assertThrows(PidException.class, () -> authenticator.getToken());
   }
 
 }


### PR DESCRIPTION
## Features
- Tombstone source system, MAS, data mapping
     - change ods:status, increment version, set date modified to current time, add tombstone metadata
- Add handle tombstone request
- Retrieve agent information from the token. if orcid is not present, throw ForbiddenException
- Send tombstoneEvent to prov service

## Small changes
- rename "delete" functions to "tombstone"
- add rdfs:comment to prov event
- Combine `PidCreationException` and `PidAuthenticationException` into `PidException` -> don't need both


## Exception handling for MAS
- before, the last step of we deleted the deployment last. 
- however, this is the only step that if it fails, we roll back to previous state. we don't rollback if handle, repo, or kafka fails
- now we try to delete the deployment first. If that fails, we back off and leave things as they are
