### PR TITLE
Don't run invalid source systems

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -104,7 +104,7 @@ public class SourceSystemController {
   @PostMapping(value = "/{prefix}/{suffix}/run", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> scheduleRunSourceSystemById(
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
-      throws ProcessingFailedException {
+      throws ProcessingFailedException, NotFoundException {
     var id = prefix + '/' + suffix;
     log.info("Received a request to start a new run for Source System: {}", id);
     service.runSourceSystemById(id);

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -46,6 +46,7 @@ import eu.dissco.orchestration.backend.repository.SourceSystemRepository;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
 import eu.dissco.orchestration.backend.schema.SourceSystem.OdsTranslatorType;
 import eu.dissco.orchestration.backend.schema.SourceSystemRequest;
+import eu.dissco.orchestration.backend.schema.TombstoneMetadata;
 import eu.dissco.orchestration.backend.web.HandleComponent;
 import freemarker.template.Configuration;
 import io.kubernetes.client.openapi.ApiException;
@@ -331,6 +332,26 @@ class SourceSystemServiceTest {
 
     // Then
     assertDoesNotThrow(() -> service.runSourceSystemById(HANDLE));
+  }
+
+  @Test
+  void testRunSourceSystemByIdNotFound() {
+    // Given
+    given(repository.getSourceSystem(HANDLE)).willReturn(null);
+
+
+    // When / Then
+    assertThrowsExactly(NotFoundException.class, () -> service.runSourceSystemById(HANDLE));
+  }
+
+  @Test
+  void testRunSourceSystemByIdTombstoned() {
+    // Given
+    var sourceSystem = givenSourceSystem().withOdsHasTombstoneMetadata(new TombstoneMetadata());
+    given(repository.getSourceSystem(HANDLE)).willReturn(sourceSystem);
+
+    // When / Then
+    assertThrowsExactly(NotFoundException.class, () -> service.runSourceSystemById(HANDLE));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
the `/run` endpoint on (data) source systems triggers an ingestion in dissco. This PR checks the source system so we don't have undesirable behaviour:

- if source system doesn't exist, return a 404 (previously threw NPE)
- if source system exists but is not tombstoned, also return a 404. the ss is not active and should not be interacted with. 