### PR TITLE
Add none translator type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/orchestration/backend/exception/InvalidTranslatorTypeException.java
+++ b/src/main/java/eu/dissco/orchestration/backend/exception/InvalidTranslatorTypeException.java
@@ -1,0 +1,9 @@
+package eu.dissco.orchestration.backend.exception;
+
+public class InvalidTranslatorTypeException extends NotFoundException {
+
+  public InvalidTranslatorTypeException(String s) {
+    super(s);
+  }
+
+}

--- a/src/main/resources/json-schema/source-system-request.json
+++ b/src/main/resources/json-schema/source-system-request.json
@@ -43,7 +43,8 @@
       "description": "The serialisation of the data the endpoint provides indicating what type of Translator is required",
       "enum": [
         "dwca",
-        "biocase"
+        "biocase",
+        "none"
       ]
     },
     "ods:dataMappingID": {

--- a/src/main/resources/json-schema/source-system.json
+++ b/src/main/resources/json-schema/source-system.json
@@ -109,7 +109,8 @@
       "description": "The serialisation of the data the endpoint provides indicating what type of Translator is required",
       "enum": [
         "dwca",
-        "biocase"
+        "biocase",
+        "none"
       ]
     },
     "ods:maximumRecords": {

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -364,9 +364,6 @@ class SourceSystemServiceTest {
     // Given
     var sourceSystem = givenSourceSystem().withOdsTranslatorType(OdsTranslatorType.NONE);
     given(repository.getSourceSystem(HANDLE)).willReturn(sourceSystem);
-    var createJob = mock(APIcreateNamespacedJobRequest.class);
-    given(
-        batchV1Api.createNamespacedJob(eq(NAMESPACE), any(V1Job.class))).willReturn(createJob);
 
     // Then
     assertThrowsExactly(InvalidTranslatorTypeException.class,

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -360,6 +360,20 @@ class SourceSystemServiceTest {
   }
 
   @Test
+  void testRunSourceSystemByIdNoneType() {
+    // Given
+    var sourceSystem = givenSourceSystem().withOdsTranslatorType(OdsTranslatorType.NONE);
+    given(repository.getSourceSystem(HANDLE)).willReturn(sourceSystem);
+    var createJob = mock(APIcreateNamespacedJobRequest.class);
+    given(
+        batchV1Api.createNamespacedJob(eq(NAMESPACE), any(V1Job.class))).willReturn(createJob);
+
+    // Then
+    assertThrowsExactly(InvalidTranslatorTypeException.class,
+        () -> service.runSourceSystemById(HANDLE));
+  }
+
+  @Test
   void testRunSourceSystemByIdNotFound() {
     // Given
     given(repository.getSourceSystem(HANDLE)).willReturn(null);

--- a/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
+++ b/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
@@ -173,6 +173,11 @@ public class TestUtils {
     return givenSourceSystemRequest(OdsTranslatorType.BIOCASE);
   }
 
+  public static SourceSystemRequest givenSourceSystemRequestNoneTranslator(){
+    return givenSourceSystemRequest(OdsTranslatorType.NONE)
+        .withSchemaUrl(URI.create(""));
+  }
+
   public static SourceSystemRequest givenSourceSystemRequest(OdsTranslatorType translatorType) {
     return new SourceSystemRequest()
         .withSchemaName(OBJECT_NAME)


### PR DESCRIPTION
Introducing the :sparkles: None :sparkles: Translator for source systems

**Why?**
We want to have a source system that doesn't trigger a translator job. The use case for this would be if we receive a csv or some other local file we only want to ingest once. 

**Why now?**
I'm ingesting the spider data set. I want to create a source system for the dataset, but I don't want to create any translator jobs. 
(Technically I'm creating 2 source systems: the data from the naturalis spiders and the data from the manchester university spiders. The 27 spiders are going to be manually ingested at the same time, but because they are located at different institutions, they will have different source systems.)

**What does it do?**
- A `None` translator type will never deploy a cron job
- if you try to trigger a run on a source system with a `none` translator type, it throws `InvalidTranslatorTypeException`
- If you update the source system from a `none` translator type to `dwc` or `biocase` translator types, the orchestration service creates a new cron job that can be scheduled/triggered immediately 

**Data model changes**
- adds `none` to translate type enum
- `schema:uri` is a required field in source systems. I assume that the uri is an empty string for `none` translator types. It doesn't matter what this field is, as it won't be used in any jobs anyway. 
    - I thought about making `schema:uri` an optional field instead of required, but Julian suggested otherwise. "This edge case shouldn't cause the data model to be weaker". Wise words from the data guy!