### PR TITLE
Adds Filters to source system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/resources/json-schema/source-system-request.json
+++ b/src/main/resources/json-schema/source-system-request.json
@@ -27,6 +27,16 @@
         "http://ipt.gbif.pt/ipt/archive.do?r=coi"
       ]
     },
+    "ods:hasFilters": {
+      "type": "array",
+      "description": "List of filters to apply to ingesting from source system. Currently only applies to BioCASe source systems",
+      "examples": [
+        "<like path='/DataSets/DataSet/Metadata/Description/Representation/Title'>Herbarium Senckenbergianum (FR)</like>"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
     "ltc:collectionManagementSystem": {
       "type": "string",
       "description": "The collection management system that the source system is using, https://rs.tdwg.org/ltc/terms/collectionManagementSystem",

--- a/src/main/resources/json-schema/source-system.json
+++ b/src/main/resources/json-schema/source-system.json
@@ -97,6 +97,16 @@
         "http://ipt.gbif.pt/ipt/archive.do?r=coi"
       ]
     },
+    "ods:hasFilters": {
+      "type": "array",
+      "description": "List of filters to apply to ingesting from source system. Currently only applies to BioCASe source systems",
+      "examples": [
+        "<like path='/DataSets/DataSet/Metadata/Description/Representation/Title'>Herbarium Senckenbergianum (FR)</like>"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
     "ltc:collectionManagementSystem": {
       "type": "string",
       "description": "The collection management system that the source system is using",


### PR DESCRIPTION
Adds list of filters to data model. 

Currently, filters are only used in biocase source systems. we can extend this further down the line. 

Requires changes in openDS. If this is accepted, I'll push the changes to the openDS repo too. 

