### PR TITLE
Add rabbitmq resources for MAS !Properties changes

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,7 +1,0 @@
-# March 17
-# Issue with binutils in alpine 3.21.3
-CVE-2025-0840
-
-# March 18
-# Issue with libexpat in alpine
-CVE-2024-8176

--- a/src/main/java/eu/dissco/orchestration/backend/configuration/TemplateConfiguration.java
+++ b/src/main/java/eu/dissco/orchestration/backend/configuration/TemplateConfiguration.java
@@ -22,5 +22,14 @@ public class TemplateConfiguration {
     return configuration.getTemplate("mas-template.ftl");
   }
 
+  @Bean(name = "masRabbitBindingTemplate")
+  public Template rabbitBindingTemplate() throws IOException {
+    return configuration.getTemplate("mas-rabbitmq-binding.ftl");
+  }
+
+  @Bean(name = "masRabbitQueueTemplate")
+  public Template rabbitQueueTemplate() throws IOException {
+    return configuration.getTemplate("mas-rabbitmq-queue.ftl");
+  }
 
 }

--- a/src/main/java/eu/dissco/orchestration/backend/properties/KubernetesProperties.java
+++ b/src/main/java/eu/dissco/orchestration/backend/properties/KubernetesProperties.java
@@ -36,6 +36,18 @@ public class KubernetesProperties {
   @NotBlank
   private String kedaResource = "scaledobjects";
 
+  @NotBlank
+  private String rabbitGroup = "rabbitmq.com";
+
+  @NotBlank
+  private String rabbitVersion = "v1beta1";
+
+  @NotBlank
+  private String rabbitBindingResource = "bindings";
+
+  @NotBlank
+  private String rabbitQueueResource = "queues";
+
   @Positive
   private int kedaPatchWait = 500;
 

--- a/src/main/java/eu/dissco/orchestration/backend/properties/MachineAnnotationServiceProperties.java
+++ b/src/main/java/eu/dissco/orchestration/backend/properties/MachineAnnotationServiceProperties.java
@@ -14,7 +14,13 @@ public class MachineAnnotationServiceProperties {
   private String namespace = "machine-annotation-services";
 
   @NotBlank
+  private String rabbitNamespace = "rabbitmq";
+
+  @NotBlank
   private String masSecretStore = "mas-secrets";
+
+  @NotBlank
+  private String masRabbitExchange = "mas-exchange";
 
   @NotBlank
   private String runningEndpoint;

--- a/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
@@ -220,7 +220,8 @@ public class MachineAnnotationServiceService {
       successfulRabbitBinding = deployRabbitBindingToCluster(mas);
       deployRabbitQueueToCluster(mas);
     } catch (KubernetesFailedException e) {
-      rollbackMasCreation(mas, successfulDeployment, successfulKeda, successfulRabbitBinding, false);
+      rollbackMasCreation(mas, successfulDeployment, successfulKeda, successfulRabbitBinding,
+          false);
       throw new ProcessingFailedException("Failed to create kubernetes resources", e);
     }
   }
@@ -239,7 +240,8 @@ public class MachineAnnotationServiceService {
       log.error("Failed to create rabbitmq binding kubernetes files for: {}", mas, e);
       throw new KubernetesFailedException("Failed to deploy rabbit binding to cluster");
     } catch (ApiException e) {
-      log.error("Failed to deploy rabbitmq binding objects to cluster with code: {} and message: {}",
+      log.error(
+          "Failed to deploy rabbitmq binding objects to cluster with code: {} and message: {}",
           e.getCode(), e.getResponseBody());
       throw new KubernetesFailedException("Failed to deploy rabbit binding to cluster");
     }
@@ -427,7 +429,8 @@ public class MachineAnnotationServiceService {
   }
 
   private void rollbackMasCreation(MachineAnnotationService mas,
-      boolean rollbackDeployment, boolean rollbackKeda, boolean rollbackRabbitBinding, boolean rollbackRabbitQueue) {
+      boolean rollbackDeployment, boolean rollbackKeda, boolean rollbackRabbitBinding,
+      boolean rollbackRabbitQueue) {
     var request = fdoRecordService.buildRollbackCreateRequest(mas.getId());
     try {
       handleComponent.rollbackHandleCreation(request);
@@ -691,8 +694,9 @@ public class MachineAnnotationServiceService {
           kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
           kubernetesProperties.getRabbitQueueResource(), "mas-" + name + QUEUE).execute();
     } catch (ApiException e) {
-      log.warn(
-          "Deletion of kubernetes rabbit resources failed for record: {}, with code: {} and message: {}",
+      log.error(
+          "Deletion of kubernetes rabbit resources failed for record: {}, with code: {} and message: {}. "
+              + "Resources need to be removed manually.",
           currentMas, e.getCode(), e.getResponseBody());
     }
   }

--- a/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
@@ -255,7 +255,7 @@ public class MachineAnnotationServiceService {
       var rabbitObject = JsonParser.parseString(rabbitResource);
       customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
           kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
-          kubernetesProperties.getRabbitBindingResource(), rabbitObject).execute();
+          kubernetesProperties.getRabbitQueueResource(), rabbitObject).execute();
       return true;
     } catch (TemplateException | IOException e) {
       log.error("Failed to create rabbitmq queue kubernetes files for: {}", mas, e);
@@ -480,7 +480,7 @@ public class MachineAnnotationServiceService {
             kubernetesProperties.getRabbitQueueResource(), "mas-" + name + QUEUE).execute();
       } catch (ApiException e) {
         log.error(
-            "Fatal exception, unable to rollback kubernetes rabbitmq queuefor: {} error message with code: {} and message: {}",
+            "Fatal exception, unable to rollback kubernetes rabbitmq queue for: {} error message with code: {} and message: {}",
             mas, e.getCode(), e.getResponseBody());
       }
     }

--- a/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
@@ -247,7 +247,7 @@ public class MachineAnnotationServiceService {
     }
   }
 
-  private boolean deployRabbitQueueToCluster(MachineAnnotationService mas)
+  private void deployRabbitQueueToCluster(MachineAnnotationService mas)
       throws KubernetesFailedException {
     var name = getName(mas.getId());
     try {
@@ -256,7 +256,6 @@ public class MachineAnnotationServiceService {
       customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
           kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
           kubernetesProperties.getRabbitQueueResource(), rabbitObject).execute();
-      return true;
     } catch (TemplateException | IOException e) {
       log.error("Failed to create rabbitmq queue kubernetes files for: {}", mas, e);
       throw new KubernetesFailedException("Failed to deploy rabbit queue to cluster");

--- a/src/main/resources/templates/keda-template.ftl
+++ b/src/main/resources/templates/keda-template.ftl
@@ -1,17 +1,25 @@
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: ${name}-scaled-object
-spec:
-  scaleTargetRef:
-    name: ${name}-deployment
-  minReplicaCount: 0
-  maxReplicaCount:  ${maxReplicas}
-  triggers:
-    - type: rabbitmq
-      metadata:
-        mode: QueueLength
-        value: "1"
-        queueName: ${topicName}-queue
-      authenticationRef:
-        name: keda-trigger-auth-rabbitmq-conn
+{
+"apiVersion": "keda.sh/v1alpha1",
+"kind": "ScaledObject",
+  "metadata": {
+  "name": "${name}-scaled-object"
+  },
+  "spec": {
+    "minReplicaCount": 0,
+    "maxReplicaCount": ${maxReplicas},
+    "scaleTargetRef": {
+      "name": "${name}-deployment"
+    },
+    "triggers" : [ {
+      "type" : "rabbitmq",
+      "metadata" : {
+        "mode" : "QueueLength",
+        "value" : "1",
+        "queueName" : "${name}-queue"
+      },
+      "authenticationRef" : {
+        "name" : "keda-trigger-auth-rabbitmq-conn"
+      }
+    } ]
+  }
+}

--- a/src/main/resources/templates/mas-rabbitmq-binding.ftl
+++ b/src/main/resources/templates/mas-rabbitmq-binding.ftl
@@ -1,0 +1,17 @@
+{
+    "apiVersion": "rabbitmq.com/v1beta1",
+    "kind": "Binding",
+    "metadata": {
+        "name": "mas-${name}-binding",
+        "namespace": "rabbitmq"
+    },
+    "spec": {
+        "destination": "mas-${name}-queue",
+        "destinationType": "queue",
+        "routingKey": "${name}",
+        "source": "${exchangeName}",
+        "rabbitmqClusterReference": {
+            "name": "rabbitmq-cluster"
+        }
+    }
+}

--- a/src/main/resources/templates/mas-rabbitmq-queue.ftl
+++ b/src/main/resources/templates/mas-rabbitmq-queue.ftl
@@ -1,0 +1,17 @@
+{
+    "apiVersion": "rabbitmq.com/v1beta1",
+    "kind": "Queue",
+    "metadata": {
+        "name": "mas-${name}-queue",
+        "namespace": "rabbitmq"
+    },
+    "spec": {
+        "autoDelete": false,
+        "durable": true,
+        "name": "mas-${name}-queue",
+        "type": "quorum",
+        "rabbitmqClusterReference": {
+            "name": "rabbitmq-cluster"
+        }
+    }
+}

--- a/src/main/resources/templates/mas-template.ftl
+++ b/src/main/resources/templates/mas-template.ftl
@@ -9,8 +9,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "${pid}"
+      app: ${pid}
   template:
+    metadata:
+      labels:
+        app: ${pid}
     spec:
       containers:
       - name: ${pid}

--- a/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
@@ -316,8 +316,6 @@ class MachineAnnotationServiceServiceTest {
     var mas = givenMasRequest();
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);
-    willThrow(JsonProcessingException.class).given(rabbitMqPublisherService)
-        .publishCreateEvent(MAPPER.valueToTree(givenMas()), givenAgent());
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
     given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
@@ -333,8 +331,6 @@ class MachineAnnotationServiceServiceTest {
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     given(createCustom.execute()).willReturn(mock(Object.class)).willThrow(new ApiException());
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE),
-        anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-binding"))).willReturn(deleteCustom);
 
     // When
     assertThrowsExactly(ProcessingFailedException.class,
@@ -350,9 +346,6 @@ class MachineAnnotationServiceServiceTest {
         .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
     then(customObjectsApi).should()
         .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
-            any(Object.class));
-    then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
             any(Object.class));
     then(fdoRecordService).should().buildRollbackCreateRequest(HANDLE);
     then(handleComponent).should().rollbackHandleCreation(any());

--- a/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
@@ -311,7 +311,7 @@ class MachineAnnotationServiceServiceTest {
   }
 
   @Test
-  void testCreateMasRabbitFails() throws Exception {
+  void testCreateMasRabbitBindingFails() throws Exception {
     // Given
     var mas = givenMasRequest();
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);


### PR DESCRIPTION
Deploy Rabbit resources to the cluster when a MAS is created.
- You know the reason why GSON JSONParser was used here 
- For deletion, if it fails we need to do it manually, rolling back for these resources seems overkill and adds a lot of complexity. The resources take no space so it is not really an issue if we don't do it right away