### PR TITLE
Sync k8s resources on startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.5</version>
+    <version>3.5.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>
@@ -16,9 +16,9 @@
   <description>Backend for orchestration service</description>
   <properties>
     <java.version>17</java.version>
-    <k8s-client-java.version>22.0.0</k8s-client-java.version>
+    <k8s-client-java.version>24.0.0</k8s-client-java.version>
     <json-patch.version>1.13</json-patch.version>
-    <testcontainers.version>1.20.3</testcontainers.version>
+    <testcontainers.version>1.21.1</testcontainers.version>
     <ok-http.version>4.12.0</ok-http.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <sonar.organization>dissco</sonar.organization>

--- a/src/main/java/eu/dissco/orchestration/backend/properties/MachineAnnotationServiceProperties.java
+++ b/src/main/java/eu/dissco/orchestration/backend/properties/MachineAnnotationServiceProperties.java
@@ -14,9 +14,6 @@ public class MachineAnnotationServiceProperties {
   private String namespace = "machine-annotation-services";
 
   @NotBlank
-  private String rabbitNamespace = "rabbitmq";
-
-  @NotBlank
   private String masSecretStore = "mas-secrets";
 
   @NotBlank

--- a/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
@@ -3,12 +3,15 @@ package eu.dissco.orchestration.backend.service;
 import static eu.dissco.orchestration.backend.configuration.ApplicationConfiguration.HANDLE_PROXY;
 import static eu.dissco.orchestration.backend.utils.HandleUtils.removeProxy;
 import static eu.dissco.orchestration.backend.utils.TombstoneUtils.buildTombstoneMetadata;
+import static java.util.stream.Collectors.toMap;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
@@ -38,6 +41,7 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1Deployment;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.time.Instant;
@@ -47,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -59,10 +64,13 @@ public class MachineAnnotationServiceService {
 
   private static final String DEPLOYMENT = "-deployment";
   private static final String SCALED_OBJECT = "-scaled-object";
+  private static final String MAS_PREFIX = "mas-";
   private static final String BINDING = "-binding";
   private static final String QUEUE = "-queue";
   private static final String NAME = "name";
   private static final String VALUE = "value";
+  private static final String ITEMS = "items";
+  private static final String METADATA = "metadata";
 
   private final HandleComponent handleComponent;
   private final FdoRecordService fdoRecordService;
@@ -137,6 +145,236 @@ public class MachineAnnotationServiceService {
         .withOdsHasSecretVariables(mas.getOdsHasSecretVariables());
   }
 
+  private static boolean equalsCheckKeda(JsonObject kedaObject, JsonObject existingKedaObject) {
+    var existingSpec = existingKedaObject.get("spec").getAsJsonObject();
+    var kedaSpec = kedaObject.get("spec").getAsJsonObject();
+    return Objects.equals(kedaSpec.get("maxReplicaCount").getAsString(),
+        existingSpec.get("maxReplicaCount").getAsString()) &&
+        Objects.equals(kedaSpec.get("scaleTargetRef").getAsJsonObject().get("name").getAsString(),
+            existingSpec.get("scaleTargetRef").getAsJsonObject().get("name").getAsString()) &&
+        Objects.equals(kedaSpec.get("triggers"), existingSpec.get("triggers"));
+  }
+
+  @PostConstruct
+  public void setup() throws ApiException, TemplateException, IOException, InterruptedException {
+    var masList = repository.getMachineAnnotationServices(0, 5000);
+    synchronizeDeployment(masList);
+    synchronizeKeda(masList);
+    synchronizeRabbitBinding(masList);
+    synchronizeRabbitQueue(masList);
+  }
+
+  private void synchronizeRabbitQueue(List<MachineAnnotationService> masList)
+      throws ApiException, TemplateException, IOException, InterruptedException {
+    log.info("Synchronizing Rabbit queue resources of Machine Annotation Service");
+    var existingKedaList = customObjectsApi.listNamespacedCustomObject(
+        kubernetesProperties.getRabbitGroup(), kubernetesProperties.getRabbitVersion(),
+        properties.getNamespace(), kubernetesProperties.getRabbitQueueResource()).execute();
+    var items = new Gson().toJsonTree(existingKedaList).getAsJsonObject().get(ITEMS)
+        .getAsJsonArray();
+    if (items != null) {
+      var existingKedaMap = items.asList().stream()
+          .collect(toMap(keda -> (((JsonObject) keda).get(METADATA).getAsJsonObject()).get("name")
+                  .getAsString(),
+              keda -> keda));
+      for (var machineAnnotationService : masList) {
+        var name = getName(machineAnnotationService.getId());
+        var kedaObject = JsonParser.parseString(createRabbitQueueResource(name));
+        var existingKedaObject = existingKedaMap.get(MAS_PREFIX + name + QUEUE);
+        if (existingKedaObject == null) {
+          log.warn(
+              "Found a machine annotation service: {} without a rabbit queue, creating one",
+              machineAnnotationService.getId());
+          customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+              kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+              kubernetesProperties.getRabbitQueueResource(), kedaObject).execute();
+        } else if (equalsCheckRabbitSpec((JsonObject) kedaObject, existingKedaObject.getAsJsonObject())) {
+          log.debug("Rabbit queue resource for machine annotation service: {} is in sync with the database",
+              machineAnnotationService.getId());
+        } else {
+          log.warn(
+              "Found an out of sync Rabbit queue for machine annotation service: {}, synchronizing",
+              machineAnnotationService.getId());
+          customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+              kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+              kubernetesProperties.getRabbitQueueResource(), MAS_PREFIX + name + QUEUE).execute();
+          Thread.sleep(kubernetesProperties.getKedaPatchWait());
+          customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+              kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+              kubernetesProperties.getRabbitQueueResource(), kedaObject).execute();
+        }
+      }
+      existingKedaMap.keySet().removeAll(masList.stream()
+          .map(mas -> MAS_PREFIX + getName(mas.getId()) + QUEUE)
+          .collect(Collectors.toSet()));
+      for (var existingKeda : existingKedaMap.entrySet()) {
+        log.warn("Found a Rabbit Queue Resource: {} without a machine annotation service, deleting it",
+            existingKeda.getKey());
+        customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+            kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+            kubernetesProperties.getRabbitQueueResource(), existingKeda.getKey()).execute();
+      }
+    }
+  }
+
+  private void synchronizeRabbitBinding(List<MachineAnnotationService> masList)
+      throws TemplateException, IOException, ApiException, InterruptedException {
+    log.info("Synchronizing Rabbit binding resources of Machine Annotation Service");
+    var existingKedaList = customObjectsApi.listNamespacedCustomObject(
+        kubernetesProperties.getRabbitGroup(), kubernetesProperties.getRabbitVersion(),
+        properties.getNamespace(), kubernetesProperties.getRabbitBindingResource()).execute();
+    var items = new Gson().toJsonTree(existingKedaList).getAsJsonObject().get(ITEMS)
+        .getAsJsonArray();
+    if (items != null) {
+      var existingKedaMap = items.asList().stream()
+          .collect(toMap(keda -> (((JsonObject) keda).get(METADATA).getAsJsonObject()).get("name")
+                  .getAsString(),
+              keda -> keda));
+      for (var machineAnnotationService : masList) {
+        var name = getName(machineAnnotationService.getId());
+        var kedaObject = JsonParser.parseString(createRabbitBindingResource(name));
+        var existingKedaObject = existingKedaMap.get(MAS_PREFIX + name + BINDING);
+        if (existingKedaObject == null) {
+          log.warn(
+              "Found a machine annotation service: {} without a rabbit binding, creating one",
+              machineAnnotationService.getId());
+          customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+              kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+              kubernetesProperties.getRabbitBindingResource(), kedaObject).execute();
+        } else if (equalsCheckRabbitSpec((JsonObject) kedaObject, existingKedaObject.getAsJsonObject())) {
+          log.debug("Rabbit binding resource for machine annotation service: {} is in sync with the database",
+              machineAnnotationService.getId());
+        } else {
+          log.warn(
+              "Found an out of sync Rabbit binding for machine annotation service: {}, synchronizing",
+              machineAnnotationService.getId());
+          customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+              kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+              kubernetesProperties.getRabbitBindingResource(), MAS_PREFIX + name + BINDING).execute();
+          Thread.sleep(kubernetesProperties.getKedaPatchWait());
+          customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+              kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+              kubernetesProperties.getRabbitBindingResource(), kedaObject).execute();
+        }
+      }
+      existingKedaMap.keySet().removeAll(masList.stream()
+          .map(mas -> MAS_PREFIX + getName(mas.getId()) + BINDING)
+          .collect(Collectors.toSet()));
+      for (var existingKeda : existingKedaMap.entrySet()) {
+        log.warn("Found a Rabbit Binding Resource: {} without a machine annotation service, deleting it",
+            existingKeda.getKey());
+        customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
+            kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+            kubernetesProperties.getRabbitBindingResource(), existingKeda.getKey()).execute();
+      }
+    }
+  }
+
+  private boolean equalsCheckRabbitSpec(JsonObject kedaObject, JsonObject existingKeda) {
+    return Objects.equals(kedaObject.get("spec"), existingKeda.get("spec"));
+  }
+
+  private void synchronizeKeda(List<MachineAnnotationService> masList)
+      throws ApiException, TemplateException, IOException, InterruptedException {
+    log.info("Synchronizing KEDA resources of Machine Annotation Service");
+    var existingKedaList = customObjectsApi.listNamespacedCustomObject(
+        kubernetesProperties.getKedaGroup(), kubernetesProperties.getKedaVersion(),
+        properties.getNamespace(), kubernetesProperties.getKedaResource()).execute();
+    var items = new Gson().toJsonTree(existingKedaList).getAsJsonObject().get(ITEMS)
+        .getAsJsonArray();
+    if (items != null) {
+      var existingKedaMap = items.asList().stream()
+          .collect(toMap(keda -> (((JsonObject) keda).get(METADATA).getAsJsonObject()).get("name")
+                  .getAsString(),
+              keda -> keda));
+      for (var machineAnnotationService : masList) {
+        var name = getName(machineAnnotationService.getId());
+        var kedaObject = createKedaFiles(machineAnnotationService, name);
+        var existingKedaObject = existingKedaMap.get(name + SCALED_OBJECT);
+        if (existingKedaObject == null) {
+          log.warn(
+              "Found a machine annotation service: {} without a keda scaled object, creating one",
+              machineAnnotationService.getId());
+          customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getKedaGroup(),
+              kubernetesProperties.getKedaVersion(), properties.getNamespace(),
+              kubernetesProperties.getKedaResource(), kedaObject).execute();
+        } else if (equalsCheckKeda((JsonObject) kedaObject, existingKedaObject.getAsJsonObject())) {
+          log.debug("Keda resource for machine annotation service: {} is in sync with the database",
+              machineAnnotationService.getId());
+        } else {
+          log.warn(
+              "Found an out of sync keda scaled object for machine annotation service: {}, synchronizing",
+              machineAnnotationService.getId());
+          customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getKedaGroup(),
+              kubernetesProperties.getKedaVersion(), properties.getNamespace(),
+              kubernetesProperties.getKedaResource(), name + SCALED_OBJECT).execute();
+          Thread.sleep(kubernetesProperties.getKedaPatchWait());
+          customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getKedaGroup(),
+              kubernetesProperties.getKedaVersion(), properties.getNamespace(),
+              kubernetesProperties.getKedaResource(), kedaObject).execute();
+        }
+      }
+      existingKedaMap.keySet().removeAll(masList.stream()
+          .map(mas -> getName(mas.getId()) + SCALED_OBJECT)
+          .collect(Collectors.toSet()));
+      for (var existingKeda : existingKedaMap.entrySet()) {
+        log.warn("Found a KEDA resource: {} without a machine annotation service, deleting it",
+            existingKeda.getKey());
+        customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getKedaGroup(),
+            kubernetesProperties.getKedaVersion(), properties.getNamespace(),
+            kubernetesProperties.getKedaResource(), existingKeda.getKey()).execute();
+      }
+    }
+  }
+
+  private void synchronizeDeployment(List<MachineAnnotationService> masList)
+      throws ApiException, TemplateException, IOException {
+    log.info("Synchronizing deployment of Machine Annotation Service");
+    var existingDeployment = appsV1Api.listNamespacedDeployment(properties.getNamespace()).execute()
+        .getItems().stream()
+        .collect(toMap(mas -> mas.getMetadata().getName(), mas -> mas));
+    for (var machineAnnotationService : masList) {
+      var databaseMasDeploy = getV1Deployment(machineAnnotationService,
+          getName(machineAnnotationService.getId()));
+      var existingMas = existingDeployment.get(
+          getName(machineAnnotationService.getId()) + DEPLOYMENT);
+      if (existingMas == null) {
+        log.warn("Found a machine annotation service: {} without a deployment, creating one",
+            machineAnnotationService.getId());
+        appsV1Api.createNamespacedDeployment(properties.getNamespace(), databaseMasDeploy)
+            .execute();
+      } else if (equalsCheckDeployment(databaseMasDeploy, existingMas)) {
+        log.debug("Deployment for machine annotation service: {} is in sync with the database",
+            machineAnnotationService.getId());
+      } else {
+        log.warn(
+            "Found an out of sync deployment for machine annotation service: {}, synchronizing",
+            machineAnnotationService.getId());
+        appsV1Api.replaceNamespacedDeployment(existingMas.getMetadata().getName(),
+            properties.getNamespace(), databaseMasDeploy).execute();
+      }
+    }
+    existingDeployment.keySet()
+        .removeAll(masList.stream().map(mas -> getName(mas.getId()) + DEPLOYMENT)
+            .collect(Collectors.toSet()));
+    for (var existingDeploy : existingDeployment.values()) {
+      log.warn("Found a deployment: {} without a machine annotation service, deleting it",
+          existingDeploy.getMetadata().getName());
+      appsV1Api.deleteNamespacedDeployment(existingDeploy.getMetadata().getName(),
+          properties.getNamespace()).execute();
+    }
+  }
+
+  private boolean equalsCheckDeployment(V1Deployment databaseMasDeploy, V1Deployment existingMas) {
+    var existingContainer = existingMas.getSpec().getTemplate().getSpec().getContainers().get(0);
+    var databaseContainer = databaseMasDeploy.getSpec().getTemplate().getSpec().getContainers()
+        .get(0);
+    return existingContainer.getName().equals(databaseContainer.getName()) &&
+        existingContainer.getImage().equals(databaseContainer.getImage()) &&
+        existingContainer.getEnv().equals(databaseContainer.getEnv()) &&
+        existingContainer.getVolumeMounts().equals(databaseContainer.getVolumeMounts());
+  }
+  
   public JsonApiWrapper createMachineAnnotationService(
       MachineAnnotationServiceRequest masRequest,
       Agent agent, String path) throws ProcessingFailedException {
@@ -233,7 +471,7 @@ public class MachineAnnotationServiceService {
       var rabbitResource = createRabbitBindingResource(name);
       var rabbitObject = JsonParser.parseString(rabbitResource);
       customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
-          kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
+          kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
           kubernetesProperties.getRabbitBindingResource(), rabbitObject).execute();
       return true;
     } catch (TemplateException | IOException e) {
@@ -254,7 +492,7 @@ public class MachineAnnotationServiceService {
       var rabbitResource = createRabbitQueueResource(name);
       var rabbitObject = JsonParser.parseString(rabbitResource);
       customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
-          kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
+          kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
           kubernetesProperties.getRabbitQueueResource(), rabbitObject).execute();
     } catch (TemplateException | IOException e) {
       log.error("Failed to create rabbitmq queue kubernetes files for: {}", mas, e);
@@ -464,7 +702,7 @@ public class MachineAnnotationServiceService {
     if (rollbackRabbitBinding) {
       try {
         customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
-            kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
+            kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
             kubernetesProperties.getRabbitBindingResource(), "mas-" + name + BINDING).execute();
       } catch (ApiException e) {
         log.error(
@@ -475,7 +713,7 @@ public class MachineAnnotationServiceService {
     if (rollbackRabbitQueue) {
       try {
         customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
-            kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
+            kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
             kubernetesProperties.getRabbitQueueResource(), "mas-" + name + QUEUE).execute();
       } catch (ApiException e) {
         log.error(
@@ -687,10 +925,10 @@ public class MachineAnnotationServiceService {
     try {
       var name = getName(currentMas.getId());
       customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
-          kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
+          kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
           kubernetesProperties.getRabbitBindingResource(), "mas-" + name + BINDING).execute();
       customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
-          kubernetesProperties.getRabbitVersion(), properties.getRabbitNamespace(),
+          kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
           kubernetesProperties.getRabbitQueueResource(), "mas-" + name + QUEUE).execute();
     } catch (ApiException e) {
       log.error(

--- a/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
@@ -188,8 +188,10 @@ public class MachineAnnotationServiceService {
           customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
               kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
               kubernetesProperties.getRabbitQueueResource(), kedaObject).execute();
-        } else if (equalsCheckRabbitSpec((JsonObject) kedaObject, existingKedaObject.getAsJsonObject())) {
-          log.debug("Rabbit queue resource for machine annotation service: {} is in sync with the database",
+        } else if (equalsCheckRabbitSpec((JsonObject) kedaObject,
+            existingKedaObject.getAsJsonObject())) {
+          log.debug(
+              "Rabbit queue resource for machine annotation service: {} is in sync with the database",
               machineAnnotationService.getId());
         } else {
           log.warn(
@@ -208,7 +210,8 @@ public class MachineAnnotationServiceService {
           .map(mas -> MAS_PREFIX + getName(mas.getId()) + QUEUE)
           .collect(Collectors.toSet()));
       for (var existingKeda : existingKedaMap.entrySet()) {
-        log.warn("Found a Rabbit Queue Resource: {} without a machine annotation service, deleting it",
+        log.warn(
+            "Found a Rabbit Queue Resource: {} without a machine annotation service, deleting it",
             existingKeda.getKey());
         customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
             kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
@@ -241,16 +244,19 @@ public class MachineAnnotationServiceService {
           customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
               kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
               kubernetesProperties.getRabbitBindingResource(), kedaObject).execute();
-        } else if (equalsCheckRabbitSpec((JsonObject) kedaObject, existingKedaObject.getAsJsonObject())) {
-          log.debug("Rabbit binding resource for machine annotation service: {} is in sync with the database",
+        } else if (equalsCheckRabbitSpec((JsonObject) kedaObject,
+            existingKedaObject.getAsJsonObject())) {
+          log.debug(
+              "Rabbit binding resource for machine annotation service: {} is in sync with the database",
               machineAnnotationService.getId());
         } else {
           log.warn(
               "Found an out of sync Rabbit binding for machine annotation service: {}, synchronizing",
               machineAnnotationService.getId());
           customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
-              kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
-              kubernetesProperties.getRabbitBindingResource(), MAS_PREFIX + name + BINDING).execute();
+                  kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
+                  kubernetesProperties.getRabbitBindingResource(), MAS_PREFIX + name + BINDING)
+              .execute();
           Thread.sleep(kubernetesProperties.getKedaPatchWait());
           customObjectsApi.createNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
               kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
@@ -261,7 +267,8 @@ public class MachineAnnotationServiceService {
           .map(mas -> MAS_PREFIX + getName(mas.getId()) + BINDING)
           .collect(Collectors.toSet()));
       for (var existingKeda : existingKedaMap.entrySet()) {
-        log.warn("Found a Rabbit Binding Resource: {} without a machine annotation service, deleting it",
+        log.warn(
+            "Found a Rabbit Binding Resource: {} without a machine annotation service, deleting it",
             existingKeda.getKey());
         customObjectsApi.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
             kubernetesProperties.getRabbitVersion(), properties.getNamespace(),
@@ -369,12 +376,12 @@ public class MachineAnnotationServiceService {
     var existingContainer = existingMas.getSpec().getTemplate().getSpec().getContainers().get(0);
     var databaseContainer = databaseMasDeploy.getSpec().getTemplate().getSpec().getContainers()
         .get(0);
-    return existingContainer.getName().equals(databaseContainer.getName()) &&
-        existingContainer.getImage().equals(databaseContainer.getImage()) &&
-        existingContainer.getEnv().equals(databaseContainer.getEnv()) &&
-        existingContainer.getVolumeMounts().equals(databaseContainer.getVolumeMounts());
+    return Objects.equals(existingContainer.getName(), databaseContainer.getName()) &&
+        Objects.equals(existingContainer.getImage(), databaseContainer.getImage()) &&
+        Objects.equals(existingContainer.getEnv(), databaseContainer.getEnv()) &&
+        Objects.equals(existingContainer.getVolumeMounts(), databaseContainer.getVolumeMounts());
   }
-  
+
   public JsonApiWrapper createMachineAnnotationService(
       MachineAnnotationServiceRequest masRequest,
       Agent agent, String path) throws ProcessingFailedException {

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -144,6 +144,18 @@ public class SourceSystemService {
                 "Source System tombstoned by agent through the orchestration backend", timestamp));
   }
 
+  private static boolean equalsCheckCron(V1CronJob cronJob, V1CronJob existingCronJob) {
+    var container = cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec()
+        .getContainers().get(0);
+    var existingContainer = existingCronJob.getSpec().getJobTemplate().getSpec().getTemplate()
+        .getSpec()
+        .getContainers().get(0);
+    return Objects.equals(container.getEnv(), existingContainer.getEnv()) &&
+        Objects.equals(container.getImage(), existingContainer.getImage()) &&
+        Objects.equals(container.getName(), existingContainer.getName()) &&
+        Objects.equals(container.getVolumeMounts(), existingContainer.getVolumeMounts());
+  }
+
   @PostConstruct
   public void setup() throws ApiException, TemplateException, IOException {
     synchronizeCronJobs();
@@ -151,46 +163,37 @@ public class SourceSystemService {
 
   private void synchronizeCronJobs() throws ApiException, TemplateException, IOException {
     log.info("Synchronizing Cron Jobs of Source System");
-    var cronJobs = batchV1Api.listNamespacedCronJob(jobProperties.getNamespace()).execute()
+    var existingCronJobMap = batchV1Api.listNamespacedCronJob(jobProperties.getNamespace())
+        .execute()
         .getItems().stream().collect(
             Collectors.toMap(cj -> cj.getMetadata().getName(), cj -> cj));
-    var sourceSystemList = repository.getSourceSystems(0, 5000);
-    for (var sourceSystem : sourceSystemList) {
-      var cronJob = setCronJobProperties(sourceSystem);
-      var existingCronJob = cronJobs.get(generateJobName(sourceSystem, true));
+    var existingSourceSystemList = repository.getSourceSystems(0, 5000);
+    for (var sourceSystem : existingSourceSystemList) {
+      var expectedCronJob = setCronJobProperties(sourceSystem);
+      var existingCronJob = existingCronJobMap.get(generateJobName(sourceSystem, true));
       if (existingCronJob == null) {
         log.warn("Found a source system: {} without a cron job, creating one",
             sourceSystem.getId());
-        batchV1Api.createNamespacedCronJob(jobProperties.getNamespace(), cronJob).execute();
-      } else if (equalsCheckCron(cronJob, existingCronJob)) {
+        batchV1Api.createNamespacedCronJob(jobProperties.getNamespace(), expectedCronJob).execute();
+      } else if (equalsCheckCron(expectedCronJob, existingCronJob)) {
         log.debug("Cronjob: {} is in sync with the database", sourceSystem.getId());
       } else {
         log.warn("Found an out of sync Cron Job, synchronizing sourceSystem: {}",
             sourceSystem.getId());
-        batchV1Api.replaceNamespacedCronJob(cronJob.getMetadata().getName(),
-            jobProperties.getNamespace(), cronJob).execute();
+        batchV1Api.replaceNamespacedCronJob(expectedCronJob.getMetadata().getName(),
+            jobProperties.getNamespace(), expectedCronJob).execute();
       }
     }
-    cronJobs.keySet()
-        .removeAll(sourceSystemList.stream().map(ss -> generateJobName(ss, true)).collect(
+    existingCronJobMap.keySet()
+        .removeAll(existingSourceSystemList.stream().map(ss -> generateJobName(ss, true)).collect(
             Collectors.toSet()));
-    for (V1CronJob cronjob : cronJobs.values()) {
+    for (V1CronJob cronjob : existingCronJobMap.values()) {
       log.warn("Found a cron job: {} without a source system, deleting it",
           cronjob.getMetadata().getName());
       batchV1Api.deleteNamespacedCronJob(cronjob.getMetadata().getName(),
           jobProperties.getNamespace()).execute();
     }
 
-  }
-
-  private static boolean equalsCheckCron(V1CronJob cronJob, V1CronJob existingCronJob) {
-    var container = cronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec().getContainers().get(0);
-    var existingContainer = existingCronJob.getSpec().getJobTemplate().getSpec().getTemplate().getSpec()
-        .getContainers().get(0);
-    return Objects.equals(container.getEnv(), existingContainer.getEnv()) &&
-        Objects.equals(container.getImage(), existingContainer.getImage()) &&
-        Objects.equals(container.getName(), existingContainer.getName()) &&
-        Objects.equals(container.getVolumeMounts(), existingContainer.getVolumeMounts());
   }
 
   private SourceSystem buildSourceSystem(

--- a/src/main/resources/templates/biocase-cron-job.ftl
+++ b/src/main/resources/templates/biocase-cron-job.ftl
@@ -33,7 +33,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: aws-secrets
-                  key: rabbitmq-username
+                  key: rabbitmq-password
             - name: application.sourceSystemId
               value: ${sourceSystemId}
           <#if maxItems??>

--- a/src/main/resources/templates/keda-template.ftl
+++ b/src/main/resources/templates/keda-template.ftl
@@ -6,7 +6,7 @@
   },
   "spec": {
     "minReplicaCount": 0,
-    "maxReplicaCount": ${maxReplicas},
+    "maxReplicaCount": ${maxReplicas}.0,
     "scaleTargetRef": {
       "name": "${name}-deployment"
     },
@@ -14,7 +14,7 @@
       "type" : "rabbitmq",
       "metadata" : {
         "mode" : "QueueLength",
-        "value" : "1",
+        "value" : "1.0",
         "queueName" : "${name}-queue"
       },
       "authenticationRef" : {

--- a/src/main/resources/templates/mas-rabbitmq-binding.ftl
+++ b/src/main/resources/templates/mas-rabbitmq-binding.ftl
@@ -3,7 +3,7 @@
     "kind": "Binding",
     "metadata": {
         "name": "mas-${name}-binding",
-        "namespace": "rabbitmq"
+        "namespace": "machine-annotation-services"
     },
     "spec": {
         "destination": "mas-${name}-queue",
@@ -11,7 +11,9 @@
         "routingKey": "${name}",
         "source": "${exchangeName}",
         "rabbitmqClusterReference": {
-            "name": "rabbitmq-cluster"
-        }
+            "name": "rabbitmq-cluster",
+            "namespace": "rabbitmq"
+        },
+        "vhost": "/"
     }
 }

--- a/src/main/resources/templates/mas-rabbitmq-queue.ftl
+++ b/src/main/resources/templates/mas-rabbitmq-queue.ftl
@@ -3,15 +3,16 @@
     "kind": "Queue",
     "metadata": {
         "name": "mas-${name}-queue",
-        "namespace": "rabbitmq"
+        "namespace": "machine-annotation-services"
     },
     "spec": {
-        "autoDelete": false,
         "durable": true,
         "name": "mas-${name}-queue",
         "type": "quorum",
+        "vhost": "/",
         "rabbitmqClusterReference": {
-            "name": "rabbitmq-cluster"
+            "name": "rabbitmq-cluster",
+            "namespace": "rabbitmq"
         }
     }
 }

--- a/src/main/resources/templates/mas-template.ftl
+++ b/src/main/resources/templates/mas-template.ftl
@@ -32,12 +32,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: aws-secrets
-              key: rabbitmq-password
+              key: rabbitmq-username
         - name: RABBITMQ_PASSWORD
           valueFrom:
             secretKeyRef:
               name: aws-secrets
-              key: rabbitmq-username
+              key: rabbitmq-password
         - name: RUNNING_ENDPOINT
           value: https://dev.dissco.tech/api/v1/mjr
         - name: GEOPICK_USER

--- a/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
@@ -22,6 +22,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenTombstone
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -35,6 +36,8 @@ import static org.mockito.Mockito.times;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
@@ -52,15 +55,24 @@ import eu.dissco.orchestration.backend.schema.SchemaContactPoint__1;
 import eu.dissco.orchestration.backend.schema.SecretVariable;
 import eu.dissco.orchestration.backend.web.HandleComponent;
 import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.AppsV1Api.APIcreateNamespacedDeploymentRequest;
 import io.kubernetes.client.openapi.apis.AppsV1Api.APIdeleteNamespacedDeploymentRequest;
+import io.kubernetes.client.openapi.apis.AppsV1Api.APIlistNamespacedDeploymentRequest;
 import io.kubernetes.client.openapi.apis.AppsV1Api.APIreplaceNamespacedDeploymentRequest;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi.APIcreateNamespacedCustomObjectRequest;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi.APIdeleteNamespacedCustomObjectRequest;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi.APIlistNamespacedCustomObjectRequest;
+import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1DeploymentList;
+import io.kubernetes.client.openapi.models.V1DeploymentSpec;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodTemplateSpec;
 import java.io.File;
 import java.io.IOException;
 import java.time.Clock;
@@ -86,9 +98,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MachineAnnotationServiceServiceTest {
 
-  private static final String MAS_NAMESPACE = "machine-annotation-services";
-  private static final String RABBIT_NAMESPACE = "rabbitmq";
-
+  private static final String NAMESPACE = "machine-annotation-services";
+  private static final Gson GSON = new Gson();
   private final Configuration configuration = new Configuration(Configuration.VERSION_2_3_32);
   private final KubernetesProperties kubernetesProperties = new KubernetesProperties();
   private final MachineAnnotationServiceProperties properties = new MachineAnnotationServiceProperties();
@@ -103,7 +114,6 @@ class MachineAnnotationServiceServiceTest {
   private HandleComponent handleComponent;
   @Mock
   private FdoRecordService fdoRecordService;
-
   @Mock
   private AppsV1Api appsV1Api;
   @Mock
@@ -123,6 +133,33 @@ class MachineAnnotationServiceServiceTest {
         Arguments.of(List.of(new EnvironmentalVariable("name", true)),
             givenMasSecrets())
     );
+  }
+
+  private static JsonElement givenKedaResource() {
+    return GSON.fromJson(
+        "{\"apiVersion\":\"keda.sh/v1alpha1\",\"items\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"kind\":\"ScaledObject\",\"metadata\":{\"name\":\"gw0-pop-xsl-scaled-object\",\"namespace\":\"machine-annotation-services\"},\"spec\":{\"maxReplicaCount\":1,\"minReplicaCount\":0,\"scaleTargetRef\":{\"name\":\"gw0-pop-xsl-deployment\"},\"triggers\":[{\"authenticationRef\":{\"name\":\"keda-trigger-auth-rabbitmq-conn\"},\"metadata\":{\"mode\":\"QueueLength\",\"queueName\":\"5y6-tzv-k3a-queue\",\"value\":\"1.0\"},\"type\":\"rabbitmq\"}]}}]}",
+        JsonElement.class);
+  }
+
+  private static JsonElement givenRabbitBinding() {
+    return GSON.fromJson(
+        "{\"apiVersion\":\"rabbitmq.com/v1beta1\",\"items\":[{\"apiVersion\":\"rabbitmq.com/v1beta1\",\"kind\":\"Binding\",\"metadata\":{\"name\":\"mas-gw0-pop-xsl-binding\",\"namespace\":\"machine-annotation-services\"},\"spec\":{\"destination\":\"mas-gw0-pop-xsl-queue\",\"destinationType\":\"queue\",\"rabbitmqClusterReference\":{\"name\":\"rabbitmq-cluster\",\"namespace\":\"rabbitmq\"},\"routingKey\":\"5y6-tzv-k3a\",\"source\":\"mas-exchange\",\"vhost\":\"/\"}}]}",
+        JsonElement.class
+    );
+  }
+
+  private static JsonElement givenRabbitQueue() {
+    return GSON.fromJson(
+        "{\"apiVersion\":\"rabbitmq.com/v1beta1\",\"items\":[{\"apiVersion\":\"rabbitmq.com/v1beta1\",\"kind\":\"Queue\",\"metadata\":{\"name\":\"mas-gw0-pop-xsl-queue\",\"namespace\":\"machine-annotation-services\"},\"spec\":{\"durable\":false,\"name\":\"mas-gw0-pop-xsl-queue\",\"rabbitmqClusterReference\":{\"name\":\"rabbitmq-cluster\",\"namespace\":\"rabbitmq\"},\"type\":\"quorum\",\"vhost\":\"/\"}}]}",
+        JsonElement.class
+    );
+  }
+
+  private static V1Deployment givenMasDeployment() {
+    return new V1Deployment().metadata(new V1ObjectMeta().name("gw0-pop-xsl-deployment"))
+        .spec(new V1DeploymentSpec().template(new V1PodTemplateSpec().spec(
+            new V1PodSpec().containers(List.of(new V1Container().name("gw0-pop-xsl-deployment")
+                .image("public.aws.amazon.com/dissco/translator:latest"))))));
   }
 
   @BeforeEach
@@ -169,13 +206,10 @@ class MachineAnnotationServiceServiceTest {
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
-        anyString(), any(Object.class))).willReturn(createCustom);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
 
     // When
@@ -186,12 +220,9 @@ class MachineAnnotationServiceServiceTest {
     then(fdoRecordService).should().buildCreateRequest(masRequest, ObjectType.MAS);
     then(repository).should().createMachineAnnotationService(expectedMas);
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
-    then(customObjectsApi).should()
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
-            any(Object.class));
-    then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
+    then(customObjectsApi).should(times(3))
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(rabbitMqPublisherService).should()
         .publishCreateEvent(MAPPER.valueToTree(expectedMas), givenAgent());
@@ -220,13 +251,10 @@ class MachineAnnotationServiceServiceTest {
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
-        anyString(), any(Object.class))).willReturn(createCustom);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
 
     // When
@@ -237,12 +265,9 @@ class MachineAnnotationServiceServiceTest {
     then(fdoRecordService).should().buildCreateRequest(masRequest, ObjectType.MAS);
     then(repository).should().createMachineAnnotationService(mas);
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
-    then(customObjectsApi).should()
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
-            any(Object.class));
-    then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
+    then(customObjectsApi).should(times(3))
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(rabbitMqPublisherService).should()
         .publishCreateEvent(MAPPER.valueToTree(mas), givenAgent());
@@ -266,7 +291,7 @@ class MachineAnnotationServiceServiceTest {
     given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     given(createDeploy.execute()).willThrow(new ApiException());
 
@@ -288,13 +313,13 @@ class MachineAnnotationServiceServiceTest {
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
     given(createCustom.execute()).willThrow(new ApiException());
 
@@ -305,11 +330,11 @@ class MachineAnnotationServiceServiceTest {
     // Then
     then(repository).should().createMachineAnnotationService(givenMas());
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
     then(handleComponent).should().rollbackHandleCreation(any());
     then(repository).should().rollbackMasCreation(HANDLE);
     then(appsV1Api).should()
-        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE));
+        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE));
   }
 
   @Test
@@ -319,19 +344,16 @@ class MachineAnnotationServiceServiceTest {
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
-        anyString(), any(Object.class))).willReturn(createCustom);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     given(createCustom.execute()).willReturn(mock(Object.class)).willThrow(new ApiException());
 
@@ -346,20 +368,17 @@ class MachineAnnotationServiceServiceTest {
     then(handleComponent).should().rollbackHandleCreation(any());
 
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
-    then(customObjectsApi).should()
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
-            any(Object.class));
-    then(customObjectsApi).should(times(1))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
+    then(customObjectsApi).should(times(2))
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(fdoRecordService).should().buildRollbackCreateRequest(HANDLE);
     then(handleComponent).should().rollbackHandleCreation(any());
     then(repository).should().rollbackMasCreation(HANDLE);
     then(appsV1Api).should()
-        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE));
+        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
   }
 
@@ -370,22 +389,19 @@ class MachineAnnotationServiceServiceTest {
     given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
     given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
-        anyString(), any(Object.class))).willReturn(createCustom);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-binding"))).willReturn(deleteCustom);
     given(createCustom.execute()).willReturn(mock(Object.class)).willReturn(mock(Object.class))
         .willThrow(new ApiException());
@@ -401,23 +417,20 @@ class MachineAnnotationServiceServiceTest {
     then(handleComponent).should().rollbackHandleCreation(any());
 
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
-    then(customObjectsApi).should()
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
-            any(Object.class));
-    then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
+    then(customObjectsApi).should(times(3))
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(fdoRecordService).should().buildRollbackCreateRequest(HANDLE);
     then(handleComponent).should().rollbackHandleCreation(any());
     then(repository).should().rollbackMasCreation(HANDLE);
     then(appsV1Api).should()
-        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE));
+        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq("mas-" + SUFFIX.toLowerCase() + "-binding"));
   }
 
@@ -430,25 +443,22 @@ class MachineAnnotationServiceServiceTest {
     willThrow(JsonProcessingException.class).given(rabbitMqPublisherService)
         .publishCreateEvent(MAPPER.valueToTree(givenMas()), givenAgent());
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
-        anyString(), any(Object.class))).willReturn(createCustom);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-binding"))).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-queue"))).willReturn(deleteCustom);
 
     // When
@@ -462,26 +472,23 @@ class MachineAnnotationServiceServiceTest {
     then(handleComponent).should().rollbackHandleCreation(any());
 
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
-    then(customObjectsApi).should()
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
-            any(Object.class));
-    then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
+    then(customObjectsApi).should(times(3))
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(fdoRecordService).should().buildRollbackCreateRequest(HANDLE);
     then(handleComponent).should().rollbackHandleCreation(any());
     then(repository).should().rollbackMasCreation(HANDLE);
     then(appsV1Api).should()
-        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE));
+        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq("mas-" + SUFFIX.toLowerCase() + "-binding"));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq("mas-" + SUFFIX.toLowerCase() + "-queue"));
   }
 
@@ -495,25 +502,22 @@ class MachineAnnotationServiceServiceTest {
         .publishCreateEvent(MAPPER.valueToTree(givenMas()), givenAgent());
     willThrow(PidException.class).given(handleComponent).rollbackHandleCreation(any());
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
-        anyString(), any(Object.class))).willReturn(createCustom);
     given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
-        anyString(), any(Object.class))).willReturn(createCustom);
+        eq(NAMESPACE), anyString(), any(Object.class))).willReturn(createCustom);
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-binding"))).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-queue"))).willReturn(deleteCustom);
 
     // When
@@ -527,26 +531,23 @@ class MachineAnnotationServiceServiceTest {
     then(handleComponent).should().rollbackHandleCreation(any());
 
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
-    then(customObjectsApi).should()
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
-            any(Object.class));
-    then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
+    then(customObjectsApi).should(times(3))
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(fdoRecordService).should().buildRollbackCreateRequest(HANDLE);
     then(handleComponent).should().rollbackHandleCreation(any());
     then(repository).should().rollbackMasCreation(HANDLE);
     then(appsV1Api).should()
-        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE));
+        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq("mas-" + SUFFIX.toLowerCase() + "-binding"));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq("mas-" + SUFFIX.toLowerCase() + "-queue"));
   }
 
@@ -560,12 +561,12 @@ class MachineAnnotationServiceServiceTest {
     given(repository.getActiveMachineAnnotationService(BARE_HANDLE)).willReturn(prevMas);
     var replaceDeploy = mock(APIreplaceNamespacedDeploymentRequest.class);
     given(appsV1Api.replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"),
-        eq(MAS_NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
+        eq(NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
 
     // When
@@ -575,13 +576,13 @@ class MachineAnnotationServiceServiceTest {
     assertThat(result).isEqualTo(expected);
     then(repository).should().updateMachineAnnotationService(givenMas(2));
     then(appsV1Api).should()
-        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE),
+        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE),
             any(V1Deployment.class));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
     then(customObjectsApi).should()
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(rabbitMqPublisherService).should()
         .publishUpdateEvent(MAPPER.valueToTree(givenMas(2)), MAPPER.valueToTree(prevMas.get()),
@@ -597,12 +598,12 @@ class MachineAnnotationServiceServiceTest {
     given(repository.getActiveMachineAnnotationService(BARE_HANDLE)).willReturn(prevMas);
     var replaceDeploy = mock(APIreplaceNamespacedDeploymentRequest.class);
     given(appsV1Api.replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"),
-        eq(MAS_NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
+        eq(NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
     given(createCustom.execute()).willThrow(new ApiException());
 
@@ -614,13 +615,13 @@ class MachineAnnotationServiceServiceTest {
     then(repository).should().updateMachineAnnotationService(givenMas(2));
     then(repository).should().updateMachineAnnotationService(prevMas.get());
     then(appsV1Api).should(times(2))
-        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE),
+        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE),
             any(V1Deployment.class));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
     then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(rabbitMqPublisherService).shouldHaveNoInteractions();
   }
@@ -634,7 +635,7 @@ class MachineAnnotationServiceServiceTest {
     given(repository.getActiveMachineAnnotationService(BARE_HANDLE)).willReturn(prevMas);
     var replaceDeploy = mock(APIreplaceNamespacedDeploymentRequest.class);
     given(appsV1Api.replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"),
-        eq(MAS_NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
+        eq(NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
     given(replaceDeploy.execute()).willThrow(new ApiException());
 
     // When
@@ -645,7 +646,7 @@ class MachineAnnotationServiceServiceTest {
     then(repository).should().updateMachineAnnotationService(givenMas(2));
     then(repository).should().updateMachineAnnotationService(prevMas.get());
     then(appsV1Api).should()
-        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE),
+        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE),
             any(V1Deployment.class));
     then(customObjectsApi).shouldHaveNoInteractions();
     then(rabbitMqPublisherService).shouldHaveNoInteractions();
@@ -663,12 +664,12 @@ class MachineAnnotationServiceServiceTest {
             givenAgent());
     var replaceDeploy = mock(APIreplaceNamespacedDeploymentRequest.class);
     given(appsV1Api.replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"),
-        eq(MAS_NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
+        eq(NAMESPACE), any(V1Deployment.class))).willReturn(replaceDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), eq(SUFFIX.toLowerCase() + "-scaled-object"))).willReturn(deleteCustom);
     var createCustom = mock(APIcreateNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE),
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE),
         anyString(), any(Object.class))).willReturn(createCustom);
 
     // When
@@ -678,13 +679,13 @@ class MachineAnnotationServiceServiceTest {
     // Then
     then(repository).should().updateMachineAnnotationService(givenMas(2));
     then(appsV1Api).should(times(2))
-        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE),
+        .replaceNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE),
             any(V1Deployment.class));
     then(customObjectsApi).should(times(2))
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
     then(customObjectsApi).should(times(2))
-        .createNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .createNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             any(Object.class));
     then(repository).should().updateMachineAnnotationService(prevMas.get());
   }
@@ -782,17 +783,17 @@ class MachineAnnotationServiceServiceTest {
         Optional.of(givenMas()));
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", MAS_NAMESPACE,
+    given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", NAMESPACE,
         "scaledobjects", "gw0-pop-xsl-scaled-object")).willReturn(deleteCustom);
     mockedStatic.when(Instant::now).thenReturn(UPDATED);
     mockedClock.when(Clock::systemUTC).thenReturn(updatedClock);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-binding"))).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-queue"))).willReturn(deleteCustom);
 
     // When
@@ -801,17 +802,17 @@ class MachineAnnotationServiceServiceTest {
     // Then
     then(repository).should().tombstoneMachineAnnotationService(givenTombstoneMas(), Instant.now());
     then(appsV1Api).should()
-        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(MAS_NAMESPACE));
+        .deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"), eq(NAMESPACE));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(MAS_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq(SUFFIX.toLowerCase() + "-scaled-object"));
     then(handleComponent).should().tombstoneHandle(any(), eq(BARE_HANDLE));
     then(rabbitMqPublisherService).should().publishTombstoneEvent(any(), any(), eq(givenAgent()));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq("mas-" + SUFFIX.toLowerCase() + "-binding"));
     then(customObjectsApi).should()
-        .deleteNamespacedCustomObject(anyString(), anyString(), eq(RABBIT_NAMESPACE), anyString(),
+        .deleteNamespacedCustomObject(anyString(), anyString(), eq(NAMESPACE), anyString(),
             eq("mas-" + SUFFIX.toLowerCase() + "-queue"));
   }
 
@@ -822,15 +823,15 @@ class MachineAnnotationServiceServiceTest {
         Optional.of(givenMas()));
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", MAS_NAMESPACE,
+    given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", NAMESPACE,
         "scaledobjects", "gw0-pop-xsl-scaled-object")).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-binding"))).willReturn(deleteCustom);
     given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
-        eq(RABBIT_NAMESPACE),
+        eq(NAMESPACE),
         anyString(), eq("mas-" + SUFFIX.toLowerCase() + "-queue"))).willReturn(deleteCustom);
     doThrow(JsonProcessingException.class).when(rabbitMqPublisherService)
         .publishTombstoneEvent(any(), any(), eq(givenAgent()));
@@ -853,7 +854,7 @@ class MachineAnnotationServiceServiceTest {
         Optional.of(givenMas()));
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     given(deleteDeploy.execute()).willThrow(new ApiException());
     mockedStatic.when(Instant::now).thenReturn(UPDATED);
     mockedClock.when(Clock::systemUTC).thenReturn(updatedClock);
@@ -875,13 +876,13 @@ class MachineAnnotationServiceServiceTest {
     given(repository.getActiveMachineAnnotationService(BARE_HANDLE)).willReturn(
         Optional.of(givenMas()));
     var createDeploy = mock(APIcreateNamespacedDeploymentRequest.class);
-    given(appsV1Api.createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class)))
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class)))
         .willReturn(createDeploy);
     var deleteDeploy = mock(APIdeleteNamespacedDeploymentRequest.class);
     given(appsV1Api.deleteNamespacedDeployment(SUFFIX.toLowerCase() + "-deployment",
-        MAS_NAMESPACE)).willReturn(deleteDeploy);
+        NAMESPACE)).willReturn(deleteDeploy);
     var deleteCustom = mock(APIdeleteNamespacedCustomObjectRequest.class);
-    given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", MAS_NAMESPACE,
+    given(customObjectsApi.deleteNamespacedCustomObject("keda.sh", "v1alpha1", NAMESPACE,
         "scaledobjects", "gw0-pop-xsl-scaled-object")).willReturn(deleteCustom);
     given(deleteCustom.execute()).willThrow(new ApiException());
     mockedStatic.when(Instant::now).thenReturn(UPDATED);
@@ -895,14 +896,127 @@ class MachineAnnotationServiceServiceTest {
     then(repository).should().getActiveMachineAnnotationService(BARE_HANDLE);
     then(repository).shouldHaveNoMoreInteractions();
     then(appsV1Api).should().deleteNamespacedDeployment(eq(SUFFIX.toLowerCase() + "-deployment"),
-        eq(MAS_NAMESPACE));
+        eq(NAMESPACE));
     then(appsV1Api).should()
-        .createNamespacedDeployment(eq(MAS_NAMESPACE), any(V1Deployment.class));
+        .createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
     then(rabbitMqPublisherService).shouldHaveNoInteractions();
   }
 
   private Optional<MachineAnnotationService> buildOptionalPrev() {
     return Optional.of(givenMas(1, "Another MAS", TTL));
+  }
+
+  @Test
+  void synchronizeMissingResources()
+      throws ApiException, TemplateException, IOException, InterruptedException {
+    // Given
+    var deployResponse = mock(APIlistNamespacedDeploymentRequest.class);
+    var customResponse = mock(APIlistNamespacedCustomObjectRequest.class);
+    given(customResponse.execute()).willReturn(
+        GSON.fromJson("{ \"items\": []}", JsonElement.class));
+    given(appsV1Api.listNamespacedDeployment(NAMESPACE)).willReturn(deployResponse);
+    given(customObjectsApi.listNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString())).willReturn(customResponse);
+    given(deployResponse.execute()).willReturn(new V1DeploymentList());
+    given(repository.getMachineAnnotationServices(anyInt(), anyInt())).willReturn(
+        List.of(givenMas()));
+    given(appsV1Api.createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class))).willReturn(
+        mock(APIcreateNamespacedDeploymentRequest.class));
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString(), any(Object.class))).willReturn(
+        mock(APIcreateNamespacedCustomObjectRequest.class));
+
+    // When
+    service.setup();
+
+    //Then
+    then(appsV1Api).should().createNamespacedDeployment(eq(NAMESPACE), any(V1Deployment.class));
+  }
+
+  @Test
+  void synchronizeExcessMas()
+      throws ApiException, TemplateException, IOException, InterruptedException {
+    // Given
+    var deployResponse = mock(APIlistNamespacedDeploymentRequest.class);
+    var customKedaResponse = mock(APIlistNamespacedCustomObjectRequest.class);
+    var k8sKeda = givenKedaResource();
+    given(customKedaResponse.execute()).willReturn(k8sKeda);
+    var customRabbitBinding = mock(APIlistNamespacedCustomObjectRequest.class);
+    var k8sRabbitBinding = givenRabbitBinding();
+    given(customRabbitBinding.execute()).willReturn(k8sRabbitBinding);
+    var customRabbitQueue = mock(APIlistNamespacedCustomObjectRequest.class);
+    var k8sRabbitQueue = givenRabbitQueue();
+    given(customRabbitQueue.execute()).willReturn(k8sRabbitQueue);
+    given(appsV1Api.listNamespacedDeployment(NAMESPACE)).willReturn(deployResponse);
+    given(customObjectsApi.listNamespacedCustomObject(eq("keda.sh"), anyString(),
+        eq(NAMESPACE), anyString())).willReturn(customKedaResponse);
+    given(customObjectsApi.listNamespacedCustomObject(eq("rabbitmq.com"), anyString(),
+        eq(NAMESPACE), eq("bindings"))).willReturn(customRabbitBinding);
+    given(customObjectsApi.listNamespacedCustomObject(eq("rabbitmq.com"), anyString(),
+        eq(NAMESPACE), eq("queues"))).willReturn(customRabbitQueue);
+    given(deployResponse.execute()).willReturn(
+        new V1DeploymentList().addItemsItem(givenMasDeployment()));
+    given(repository.getMachineAnnotationServices(anyInt(), anyInt())).willReturn(List.of());
+    given(appsV1Api.deleteNamespacedDeployment(anyString(), eq(NAMESPACE))).willReturn(
+        mock(APIdeleteNamespacedDeploymentRequest.class));
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString(), anyString())).willReturn(
+        mock(APIdeleteNamespacedCustomObjectRequest.class));
+
+    // When
+    service.setup();
+
+    //Then
+    then(appsV1Api).should().deleteNamespacedDeployment(anyString(), eq(NAMESPACE));
+    then(customObjectsApi).should(times(3)).deleteNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString(), anyString());
+  }
+
+  @Test
+  void synchronizeOutOfSyncMas()
+      throws ApiException, TemplateException, IOException, InterruptedException {
+    // Given
+    given(repository.getMachineAnnotationServices(anyInt(), anyInt())).willReturn(
+        List.of(givenMas()));
+    var deployResponse = mock(APIlistNamespacedDeploymentRequest.class);
+    var customKedaResponse = mock(APIlistNamespacedCustomObjectRequest.class);
+    var k8sKeda = givenKedaResource();
+    given(customKedaResponse.execute()).willReturn(k8sKeda);
+    var customRabbitBinding = mock(APIlistNamespacedCustomObjectRequest.class);
+    var k8sRabbitBinding = givenRabbitBinding();
+    given(customRabbitBinding.execute()).willReturn(k8sRabbitBinding);
+    var customRabbitQueue = mock(APIlistNamespacedCustomObjectRequest.class);
+    var k8sRabbitQueue = givenRabbitQueue();
+    given(customRabbitQueue.execute()).willReturn(k8sRabbitQueue);
+    given(appsV1Api.listNamespacedDeployment(NAMESPACE)).willReturn(deployResponse);
+    given(customObjectsApi.listNamespacedCustomObject(eq("keda.sh"), anyString(),
+        eq(NAMESPACE), anyString())).willReturn(customKedaResponse);
+    given(customObjectsApi.listNamespacedCustomObject(eq("rabbitmq.com"), anyString(),
+        eq(NAMESPACE), eq("bindings"))).willReturn(customRabbitBinding);
+    given(customObjectsApi.listNamespacedCustomObject(eq("rabbitmq.com"), anyString(),
+        eq(NAMESPACE), eq("queues"))).willReturn(customRabbitQueue);
+    given(deployResponse.execute()).willReturn(
+        new V1DeploymentList().addItemsItem(givenMasDeployment()));
+    given(appsV1Api.replaceNamespacedDeployment(anyString(), eq(NAMESPACE), any(
+        V1Deployment.class))).willReturn(
+        mock(APIreplaceNamespacedDeploymentRequest.class));
+    given(customObjectsApi.deleteNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString(), anyString())).willReturn(
+        mock(APIdeleteNamespacedCustomObjectRequest.class));
+    given(customObjectsApi.createNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString(), any(Object.class))).willReturn(
+        mock(APIcreateNamespacedCustomObjectRequest.class));
+
+    // When
+    service.setup();
+
+    //Then
+    then(appsV1Api).should().replaceNamespacedDeployment(anyString(), eq(NAMESPACE), any(
+        V1Deployment.class));
+    then(customObjectsApi).should(times(3)).deleteNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString(), anyString());
+    then(customObjectsApi).should(times(3)).createNamespacedCustomObject(anyString(), anyString(),
+        eq(NAMESPACE), anyString(), any(Object.class));
   }
 
   private void initTime() {


### PR DESCRIPTION
Checks on startup if the k8s resources are in sync with the database. Database is leading!
For source system it check the cronjob
For MAS it checks all four resources that are created (deployment, KEDA, RabbitBinding, RabbitQueue)

Additional change to Rabbit queue and binding is that they are deployed in the MAS namespace.
Option is added to the Rabbit cluster to make them discoverable.