### PR TITLE
Add cronjob for DWCA export + add download link for dwca  ! deployment changes

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/component/StringToExportTypeConverter.java
+++ b/src/main/java/eu/dissco/orchestration/backend/component/StringToExportTypeConverter.java
@@ -1,0 +1,13 @@
+package eu.dissco.orchestration.backend.component;
+
+import eu.dissco.orchestration.backend.domain.ExportType;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToExportTypeConverter implements Converter<String, ExportType> {
+
+
+  @Override
+  public ExportType convert(String exportTypeName) {
+    return ExportType.fromName(exportTypeName);
+  }
+}

--- a/src/main/java/eu/dissco/orchestration/backend/configuration/WebServerConfiguration.java
+++ b/src/main/java/eu/dissco/orchestration/backend/configuration/WebServerConfiguration.java
@@ -1,0 +1,16 @@
+package eu.dissco.orchestration.backend.configuration;
+
+import eu.dissco.orchestration.backend.component.StringToExportTypeConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebServerConfiguration implements WebMvcConfigurer {
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new StringToExportTypeConverter());
+  }
+
+}

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -108,7 +108,7 @@ public class SourceSystemController {
 
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/{prefix}/{suffix}/download/{export-type}")
-  public ResponseEntity<Resource> getSourceSystemDwcDp(@PathVariable("prefix") String prefix,
+  public ResponseEntity<Resource> getSourceSystemDownload(@PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, @PathVariable("export-type") String exportType) throws URISyntaxException, NotFoundException {
     var id = prefix + '/' + suffix;
     if (!ALLOWED_EXPORT_TYPES.contains(exportType)) {
@@ -116,7 +116,7 @@ public class SourceSystemController {
       throw new NotFoundException("Export type " + exportType + " is not allowed for source system: " + id);
     }
     log.info("Received {} for source system with id: {}", exportType, id);
-    var dwcDpInputStream = service.getSourceSystemDwcDp(id, exportType);
+    var dwcDpInputStream = service.getSourceSystemDownload(id, exportType);
     var resource = new InputStreamResource(dwcDpInputStream);
     return ResponseEntity.ok()
         .contentType(MediaType.parseMediaType("application/zip"))

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -6,6 +6,7 @@ import static eu.dissco.orchestration.backend.utils.ControllerUtils.getAgent;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiListWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
@@ -109,12 +110,8 @@ public class SourceSystemController {
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/{prefix}/{suffix}/download/{export-type}")
   public ResponseEntity<Resource> getSourceSystemDownload(@PathVariable("prefix") String prefix,
-      @PathVariable("suffix") String suffix, @PathVariable("export-type") String exportType) throws URISyntaxException, NotFoundException {
+      @PathVariable("suffix") String suffix, @PathVariable("export-type") ExportType exportType) throws URISyntaxException, NotFoundException {
     var id = prefix + '/' + suffix;
-    if (!ALLOWED_EXPORT_TYPES.contains(exportType)) {
-      log.error("Export type {} is not allowed for source system: {}", exportType, id);
-      throw new NotFoundException("Export type " + exportType + " is not allowed for source system: " + id);
-    }
     log.info("Received {} for source system with id: {}", exportType, id);
     var dwcDpInputStream = service.getSourceSystemDownload(id, exportType);
     var resource = new InputStreamResource(dwcDpInputStream);

--- a/src/main/java/eu/dissco/orchestration/backend/domain/ExportType.java
+++ b/src/main/java/eu/dissco/orchestration/backend/domain/ExportType.java
@@ -1,0 +1,24 @@
+package eu.dissco.orchestration.backend.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ExportType {
+  DWC_DP("dwc-dp"),
+  DWCA("dwca");
+
+  private final String urlName;
+
+  ExportType(String urlName) {
+    this.urlName = urlName;
+  }
+
+  public static ExportType fromName(String name) {
+    for (ExportType type : ExportType.values()) {
+      if (type.getUrlName().equals(name)) {
+        return type;
+      }
+    }
+    throw new IllegalArgumentException("Unknown export type: " + name);
+  }
+}

--- a/src/main/java/eu/dissco/orchestration/backend/properties/TranslatorJobProperties.java
+++ b/src/main/java/eu/dissco/orchestration/backend/properties/TranslatorJobProperties.java
@@ -1,9 +1,12 @@
 package eu.dissco.orchestration.backend.properties;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
@@ -23,4 +26,19 @@ public class TranslatorJobProperties {
   @Value("${spring.datasource.url}")
   private String databaseUrl;
 
+  @Valid
+  private Export export = new Export();
+
+  @Data
+  @Validated
+  public static class Export {
+    @NotBlank
+    private String exportImage;
+    @NotBlank
+    private String keycloak;
+    @NotBlank
+    private String disscoDomain;
+    @NotBlank
+    private String namespace = "data-export-job";
+  }
 }

--- a/src/main/java/eu/dissco/orchestration/backend/properties/TranslatorJobProperties.java
+++ b/src/main/java/eu/dissco/orchestration/backend/properties/TranslatorJobProperties.java
@@ -2,11 +2,9 @@ package eu.dissco.orchestration.backend.properties;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
@@ -32,6 +30,7 @@ public class TranslatorJobProperties {
   @Data
   @Validated
   public static class Export {
+
     @NotBlank
     private String exportImage;
     @NotBlank

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -7,6 +7,7 @@ import static eu.dissco.orchestration.backend.utils.HandleUtils.removeProxy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
+import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
@@ -114,11 +115,10 @@ public class SourceSystemRepository {
         .execute();
   }
 
-  public String getExportLink(String id, String exportType) throws NotFoundException {
+  public String getExportLink(String id, ExportType exportType) {
     var linkColumn = switch (exportType) {
-      case "dwc-dp" -> SOURCE_SYSTEM.DWC_DP_LINK;
-      case "dwca" -> SOURCE_SYSTEM.DWCA_LINK;
-      default -> throw new NotFoundException("Unsupported export type: " + exportType);
+      case DWC_DP -> SOURCE_SYSTEM.DWC_DP_LINK;
+      case DWCA -> SOURCE_SYSTEM.DWCA_LINK;
     };
     return context.select(linkColumn)
         .from(SOURCE_SYSTEM)

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
 import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
-import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
 import java.time.Instant;
 import java.util.List;

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
 import java.time.Instant;
 import java.util.List;
@@ -113,11 +114,11 @@ public class SourceSystemRepository {
         .execute();
   }
 
-  public String getExportLink(String id, String exportType) {
+  public String getExportLink(String id, String exportType) throws NotFoundException {
     var linkColumn = switch (exportType) {
       case "dwc-dp" -> SOURCE_SYSTEM.DWC_DP_LINK;
       case "dwca" -> SOURCE_SYSTEM.DWCA_LINK;
-      default -> throw new IllegalArgumentException("Unsupported export type: " + exportType);
+      default -> throw new NotFoundException("Unsupported export type: " + exportType);
     };
     return context.select(linkColumn)
         .from(SOURCE_SYSTEM)

--- a/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
+++ b/src/main/java/eu/dissco/orchestration/backend/repository/SourceSystemRepository.java
@@ -113,8 +113,13 @@ public class SourceSystemRepository {
         .execute();
   }
 
-  public String getDwcDpLink(String id) {
-    return context.select(SOURCE_SYSTEM.DWC_DP_LINK)
+  public String getExportLink(String id, String exportType) {
+    var linkColumn = switch (exportType) {
+      case "dwc-dp" -> SOURCE_SYSTEM.DWC_DP_LINK;
+      case "dwca" -> SOURCE_SYSTEM.DWCA_LINK;
+      default -> throw new IllegalArgumentException("Unsupported export type: " + exportType);
+    };
+    return context.select(linkColumn)
         .from(SOURCE_SYSTEM)
         .where(SOURCE_SYSTEM.ID.eq(id))
         .fetchOne(Record1::value1);

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.domain.Enrichment;
+import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
@@ -317,7 +318,7 @@ public class SourceSystemService {
     map.put("namespace", jobProperties.getExport().getNamespace());
     map.put("jobName", jobName);
     map.put("jobImage", jobProperties.getExport().getExportImage());
-    map.put("KeycloakServer", jobProperties.getExport().getKeycloak());
+    map.put("keycloakServer", jobProperties.getExport().getKeycloak());
     map.put("disscoDomain", jobProperties.getExport().getDisscoDomain());
     map.put("sourceSystemId", sourceSystem.getId());
     map.put("exportType", "DWCA");
@@ -668,7 +669,7 @@ public class SourceSystemService {
     }
   }
 
-  public InputStream getSourceSystemDownload(String id, String exportType)
+  public InputStream getSourceSystemDownload(String id, ExportType exportType)
       throws URISyntaxException, NotFoundException {
     var fileLocation = repository.getExportLink(id, exportType);
     if (fileLocation == null) {

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -668,7 +668,7 @@ public class SourceSystemService {
     }
   }
 
-  public InputStream getSourceSystemDwcDp(String id, String exportType)
+  public InputStream getSourceSystemDownload(String id, String exportType)
       throws URISyntaxException, NotFoundException {
     var fileLocation = repository.getExportLink(id, exportType);
     if (fileLocation == null) {

--- a/src/main/resources/templates/mas-rabbitmq-queue.ftl
+++ b/src/main/resources/templates/mas-rabbitmq-queue.ftl
@@ -10,6 +10,7 @@
         "name": "mas-${name}-queue",
         "type": "quorum",
         "vhost": "/",
+        "deletionPolicy": "delete",
         "rabbitmqClusterReference": {
             "name": "rabbitmq-cluster",
             "namespace": "rabbitmq"

--- a/src/main/resources/templates/source-system-cron-job.ftl
+++ b/src/main/resources/templates/source-system-cron-job.ftl
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ${jobName}
+  namespace: ${namespace}
+spec:
+  schedule: "${cron}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: ${jobName}
+              image: ${ jobImage }
+              env:
+                - name: KEYCLOAK_SERVER
+                  value: ${KeycloakServer}
+                - name: REALM
+                  value: dissco
+                - name: CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: aws-secrets
+                      key: export-client-id
+                - name: CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: aws-secrets
+                      key: export-client-secret
+                - name: SOURCE_SYSTEM_ID
+                  value: ${sourceSystemId}
+                - name: DISSCO_DOMAIN
+                  value: ${disscoDomain}
+                - name: EXPORT_TYPE
+                  value: ${exportType}
+          restartPolicy: Never

--- a/src/main/resources/templates/source-system-cron-job.ftl
+++ b/src/main/resources/templates/source-system-cron-job.ftl
@@ -14,7 +14,7 @@ spec:
               image: ${ jobImage }
               env:
                 - name: KEYCLOAK_SERVER
-                  value: ${KeycloakServer}
+                  value: ${keycloakServer}
                 - name: REALM
                   value: dissco
                 - name: CLIENT_ID

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -16,11 +16,12 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSys
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemResponse;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemSingleJsonApiWrapper;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
@@ -128,7 +129,7 @@ class SourceSystemControllerTest {
   @Test
   void testDownloadSourceSystemDwcDp() throws URISyntaxException, IOException, NotFoundException {
     // Given
-    var exportType = "dwc-dp";
+    var exportType = ExportType.DWC_DP;
     given(service.getSourceSystemDownload(BARE_HANDLE, exportType)).willReturn(
         new ByteArrayInputStream("test".getBytes()));
 
@@ -138,18 +139,9 @@ class SourceSystemControllerTest {
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(new String(result.getBody().getContentAsByteArray())).isEqualTo("test");
-    assertThat(result.getHeaders().containsValue(List.of("application/zip"))).isTrue();
-    assertThat(result.getHeaders().containsValue(List.of("attachment; filename=\"20.5000.1025_gw0-pop-xsl_dwc-dp.zip\""))).isTrue();
-  }
-
-  @Test
-  void testDownloadSourceSystemTypeNotExists() {
-    // Given
-    var exportType = "test-export-type";
-
-    // When / Then
-    assertThrows(NotFoundException.class,
-        () -> controller.getSourceSystemDownload(PREFIX, SUFFIX, exportType));
+    assertTrue(result.getHeaders().containsValue(List.of("application/zip")));
+    assertTrue(result.getHeaders().containsValue(
+        List.of("attachment; filename=\"20.5000.1025_gw0-pop-xsl_dwc-dp.zip\"")));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -1,5 +1,6 @@
 package eu.dissco.orchestration.backend.controller;
 
+import static eu.dissco.orchestration.backend.domain.ObjectType.SOURCE_SYSTEM;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.BARE_HANDLE;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.MAPPER;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.PREFIX;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequest;
@@ -62,6 +64,14 @@ class SourceSystemControllerTest {
   @Mock
   private Authentication authentication;
 
+  private static Stream<Arguments> badSourceSystemRequest() {
+    return Stream.of(
+        Arguments.of("schema:url"),
+        Arguments.of("ods:translatorType"),
+        Arguments.of("ods:dataMappingID"),
+        Arguments.of("schema:name"));
+  }
+
   @BeforeEach
   void setup() {
     controller = new SourceSystemController(service, MAPPER, appProperties);
@@ -98,18 +108,11 @@ class SourceSystemControllerTest {
     // Given
     var requestBody = (ObjectNode) givenSourceSystemRequestJson().data().attributes();
     requestBody.remove(fieldToRemove);
-    var request = new JsonApiRequestWrapper(new JsonApiRequest(ObjectType.SOURCE_SYSTEM, requestBody));
+    var request = new JsonApiRequestWrapper(new JsonApiRequest(SOURCE_SYSTEM, requestBody));
 
     // When / Then
-    assertThrows(IllegalArgumentException.class, () -> controller.createSourceSystem(authentication, request, mockRequest));
-  }
-
-  private static Stream<Arguments> badSourceSystemRequest() {
-    return Stream.of(
-        Arguments.of("schema:url"),
-        Arguments.of("ods:translatorType"),
-        Arguments.of("ods:dataMappingID"),
-        Arguments.of("schema:name"));
+    assertThrows(IllegalArgumentException.class,
+        () -> controller.createSourceSystem(authentication, request, mockRequest));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -16,6 +16,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSys
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemResponse;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemSingleJsonApiWrapper;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -127,17 +128,28 @@ class SourceSystemControllerTest {
   @Test
   void testDownloadSourceSystemDwcDp() throws URISyntaxException, IOException, NotFoundException {
     // Given
-    given(service.getSourceSystemDwcDp(BARE_HANDLE)).willReturn(
+    var exportType = "dwc-dp";
+    given(service.getSourceSystemDwcDp(BARE_HANDLE, exportType)).willReturn(
         new ByteArrayInputStream("test".getBytes()));
 
     // When
-    var result = controller.getSourceSystemDwcDp(PREFIX, SUFFIX);
+    var result = controller.getSourceSystemDwcDp(PREFIX, SUFFIX, exportType);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(new String(result.getBody().getContentAsByteArray())).isEqualTo("test");
     assertThat(result.getHeaders().containsValue(List.of("application/zip"))).isTrue();
     assertThat(result.getHeaders().containsValue(List.of("attachment; filename=\"20.5000.1025_gw0-pop-xsl_dwc-dp.zip\""))).isTrue();
+  }
+
+  @Test
+  void testDownloadSourceSystemTypeNotExists() {
+    // Given
+    var exportType = "test-export-type";
+
+    // When / Then
+    assertThrows(NotFoundException.class,
+        () -> controller.getSourceSystemDwcDp(PREFIX, SUFFIX, exportType));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -129,11 +129,11 @@ class SourceSystemControllerTest {
   void testDownloadSourceSystemDwcDp() throws URISyntaxException, IOException, NotFoundException {
     // Given
     var exportType = "dwc-dp";
-    given(service.getSourceSystemDwcDp(BARE_HANDLE, exportType)).willReturn(
+    given(service.getSourceSystemDownload(BARE_HANDLE, exportType)).willReturn(
         new ByteArrayInputStream("test".getBytes()));
 
     // When
-    var result = controller.getSourceSystemDwcDp(PREFIX, SUFFIX, exportType);
+    var result = controller.getSourceSystemDownload(PREFIX, SUFFIX, exportType);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -149,7 +149,7 @@ class SourceSystemControllerTest {
 
     // When / Then
     assertThrows(NotFoundException.class,
-        () -> controller.getSourceSystemDwcDp(PREFIX, SUFFIX, exportType));
+        () -> controller.getSourceSystemDownload(PREFIX, SUFFIX, exportType));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -92,7 +92,7 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetDownloadLink() throws JsonProcessingException, NotFoundException {
+  void testGetDownloadLink() throws JsonProcessingException {
     // Given
     var exportType = ExportType.DWC_DP;
     postSourceSystem(List.of(givenSourceSystem()));

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
+import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
 import eu.dissco.orchestration.backend.schema.SourceSystem.OdsStatus;
 import eu.dissco.orchestration.backend.schema.SourceSystem.OdsTranslatorType;
@@ -90,7 +91,7 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetDownloadLink() throws JsonProcessingException {
+  void testGetDownloadLink() throws JsonProcessingException, NotFoundException {
     // Given
     var exportType = "dwc-dp";
     postSourceSystem(List.of(givenSourceSystem()));

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -90,7 +90,7 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetDwcDpLink() throws JsonProcessingException {
+  void testGetDownloadLink() throws JsonProcessingException {
     // Given
     var exportType = "dwc-dp";
     postSourceSystem(List.of(givenSourceSystem()));

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
+import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
@@ -93,7 +94,7 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
   @Test
   void testGetDownloadLink() throws JsonProcessingException, NotFoundException {
     // Given
-    var exportType = "dwc-dp";
+    var exportType = ExportType.DWC_DP;
     postSourceSystem(List.of(givenSourceSystem()));
 
     // When

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -16,7 +16,6 @@ import eu.dissco.orchestration.backend.database.jooq.enums.TranslatorType;
 import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.exception.DisscoJsonBMappingException;
-import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
 import eu.dissco.orchestration.backend.schema.SourceSystem.OdsStatus;
 import eu.dissco.orchestration.backend.schema.SourceSystem.OdsTranslatorType;

--- a/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
+++ b/src/test/java/eu/dissco/orchestration/backend/repository/SourceSystemRepositoryIT.java
@@ -92,10 +92,11 @@ class SourceSystemRepositoryIT extends BaseRepositoryIT {
   @Test
   void testGetDwcDpLink() throws JsonProcessingException {
     // Given
+    var exportType = "dwc-dp";
     postSourceSystem(List.of(givenSourceSystem()));
 
     // When
-    var result = repository.getDwcDpLink(BARE_HANDLE);
+    var result = repository.getExportLink(BARE_HANDLE, exportType);
 
     // Then
     assertThat(result).isEqualTo(DWC_DP_S3_URI);

--- a/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
@@ -159,7 +159,7 @@ class MachineAnnotationServiceServiceTest {
     return GSON.fromJson(
         "{\"apiVersion\":\"rabbitmq.com/v1beta1\",\"items\":[{\"apiVersion\":\"rabbitmq.com/v1beta1\",\"kind\":\"Queue\",\"metadata\":{\"name\":\"mas-gw0-pop-xsl-queue\",\"namespace\":\"machine-annotation-services\"},\"spec\":{\"durable\":"
             + durable
-            + ",\"name\":\"mas-gw0-pop-xsl-queue\",\"rabbitmqClusterReference\":{\"name\":\"rabbitmq-cluster\",\"namespace\":\"rabbitmq\"},\"type\":\"quorum\",\"vhost\":\"/\"}}]}",
+            + ",\"name\":\"mas-gw0-pop-xsl-queue\",\"rabbitmqClusterReference\":{\"name\":\"rabbitmq-cluster\",\"namespace\":\"rabbitmq\"},\"type\":\"quorum\",\"deletionPolicy\": \"delete\",\"vhost\":\"/\"}}]}",
         JsonElement.class
     );
   }

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -633,7 +633,7 @@ class SourceSystemServiceTest {
     given(s3Client.getObject(getObjectRequest)).willReturn(mock(ResponseInputStream.class));
 
     // When
-    service.getSourceSystemDwcDp(HANDLE, exportType);
+    service.getSourceSystemDownload(HANDLE, exportType);
 
     // Then
     then(s3Client).should().getObject(getObjectRequest);
@@ -646,7 +646,7 @@ class SourceSystemServiceTest {
     given(repository.getExportLink(HANDLE, exportType)).willReturn(null);
 
     // When / Then
-    assertThrows(NotFoundException.class, () -> service.getSourceSystemDwcDp(HANDLE, exportType));
+    assertThrows(NotFoundException.class, () -> service.getSourceSystemDownload(HANDLE, exportType));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -640,7 +640,7 @@ class SourceSystemServiceTest {
   }
 
   @Test
-  void testGetSourceSystemDwcDpNotFound() {
+  void testGetSourceSystemDwcDpNotFound() throws NotFoundException {
     // Given
     var exportType = "dwca";
     given(repository.getExportLink(HANDLE, exportType)).willReturn(null);

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.times;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import eu.dissco.orchestration.backend.domain.ExportType;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
@@ -625,7 +626,7 @@ class SourceSystemServiceTest {
   @Test
   void testGetSourceSystemDwcDp() throws URISyntaxException, NotFoundException {
     // Given
-    var exportType = "dwc-dp";
+    var exportType = ExportType.DWC_DP;
     given(repository.getExportLink(HANDLE, exportType)).willReturn(DWC_DP_S3_URI);
     var getObjectRequest = GetObjectRequest.builder()
         .key("2025-06-20/36a61c1d-0734-4549-b3f3-ba78233bcb5d.zip")
@@ -642,7 +643,7 @@ class SourceSystemServiceTest {
   @Test
   void testGetSourceSystemDwcDpNotFound() throws NotFoundException {
     // Given
-    var exportType = "dwca";
+    var exportType = ExportType.DWCA;
     given(repository.getExportLink(HANDLE, exportType)).willReturn(null);
 
     // When / Then

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -641,7 +641,7 @@ class SourceSystemServiceTest {
   }
 
   @Test
-  void testGetSourceSystemDwcDpNotFound() throws NotFoundException {
+  void testGetSourceSystemDwcDpNotFound() {
     // Given
     var exportType = ExportType.DWCA;
     given(repository.getExportLink(HANDLE, exportType)).willReturn(null);


### PR DESCRIPTION
- Made download endpoint for source-system generic

- When new source-system get's created we deploy a cron-job which will trigger the dwca creation once a week
  - If this fails we log it but we won't fail the whole source-system. We will need to fix the issue and redeploy the orchestration-backend that will sync it. Rather not rollback everything for something we can fix another way. 
- When source-system is deleted we remove the cronjob
- On startup of the orchestration backend we sync the export cronjobs 
- 
https://naturalis.atlassian.net/browse/DD-1747