### PR TITLE
Check for missing required fields

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/controller/DataMappingController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/DataMappingController.java
@@ -114,10 +114,15 @@ public class DataMappingController {
   private DataMappingRequest getDataMappingRequestFromRequest(JsonApiRequestWrapper requestBody)
       throws JsonProcessingException, IllegalArgumentException {
     if (!requestBody.data().type().equals(ObjectType.DATA_MAPPING)) {
-      log.error("Incorrect type for this endpoint: {}", requestBody.data().type());
+      log.warn("Incorrect type for this endpoint: {}", requestBody.data().type());
       throw new IllegalArgumentException();
     }
-    return mapper.treeToValue(requestBody.data().attributes(), DataMappingRequest.class);
+    var request =  mapper.treeToValue(requestBody.data().attributes(), DataMappingRequest.class);
+    if (request.getOdsMappingDataStandard() == null || request.getSchemaName() == null) {
+      log.warn("Missing required field for data mapping creation");
+      throw new IllegalArgumentException("Missing required field for data mapping creation");
+    }
+    return request;
   }
 
 }

--- a/src/main/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceController.java
@@ -120,8 +120,13 @@ public class MachineAnnotationServiceController {
       log.error("Incorrect type for this endpoint: {}", requestBody.data().type());
       throw new IllegalArgumentException();
     }
-    return mapper.treeToValue(requestBody.data().attributes(),
+    var request = mapper.treeToValue(requestBody.data().attributes(),
         MachineAnnotationServiceRequest.class);
+    if (request.getSchemaName() == null || request.getOdsContainerImage() == null || request.getOdsHasTargetDigitalObjectFilter() == null){
+      log.warn("Missing required field for MAS creation");
+      throw new IllegalArgumentException("Missing required field for MAS creation");
+    }
+    return request;
   }
 
 }

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -151,6 +151,12 @@ public class SourceSystemController {
       log.error("Incorrect type for this endpoint: {}", requestBody.data().type());
       throw new IllegalArgumentException();
     }
-    return mapper.treeToValue(requestBody.data().attributes(), SourceSystemRequest.class);
+    var request = mapper.treeToValue(requestBody.data().attributes(), SourceSystemRequest.class);
+    if (request.getSchemaName() == null || request.getSchemaUrl() == null
+        || request.getOdsTranslatorType() == null || request.getOdsDataMappingID() == null) {
+      log.warn("Missing required field for source system creation");
+      throw new IllegalArgumentException("Missing required field for source system creation");
+    }
+    return request;
   }
 }

--- a/src/test/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/MachineAnnotationServiceControllerTest.java
@@ -13,6 +13,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasReques
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasSingleJsonApiWrapper;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRequestJson;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -21,12 +22,20 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import eu.dissco.orchestration.backend.domain.ObjectType;
+import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequest;
+import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
 import eu.dissco.orchestration.backend.service.MachineAnnotationServiceService;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -74,6 +83,25 @@ class MachineAnnotationServiceControllerTest {
     assertThrowsExactly(
         IllegalArgumentException.class,
         () -> controller.createMachineAnnotationService(authentication, requestBody, mockRequest));
+  }
+
+  @ParameterizedTest
+  @MethodSource("badMasRequest")
+  void testCreateDataMappingMissingInfo(String fieldToRemove) {
+    // Given
+    var requestBody = (ObjectNode) givenMasRequestJson().data().attributes();
+    requestBody.remove(fieldToRemove);
+    var request = new JsonApiRequestWrapper(new JsonApiRequest(ObjectType.MAS, requestBody));
+
+    // When / Then
+    assertThrows(IllegalArgumentException.class, () -> controller.createMachineAnnotationService(authentication, request, mockRequest));
+  }
+
+  private static Stream<Arguments> badMasRequest() {
+    return Stream.of(
+        Arguments.of("ods:containerImage"),
+        Arguments.of("ods:hasTargetDigitalObjectFilter"),
+        Arguments.of("schema:name"));
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -16,11 +16,16 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSys
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemResponse;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemSingleJsonApiWrapper;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
+import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequest;
+import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.orchestration.backend.exception.NotFoundException;
 import eu.dissco.orchestration.backend.properties.ApplicationProperties;
 import eu.dissco.orchestration.backend.schema.SourceSystem;
@@ -30,9 +35,13 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -81,6 +90,27 @@ class SourceSystemControllerTest {
     assertThrowsExactly(
         IllegalArgumentException.class,
         () -> controller.createSourceSystem(authentication, sourceSystem, mockRequest));
+  }
+
+  @ParameterizedTest
+  @MethodSource("badSourceSystemRequest")
+  void testCreateDataMappingMissingInfo(String fieldToRemove) {
+    // Given
+    var requestBody = (ObjectNode) givenSourceSystemRequestJson().data().attributes();
+    requestBody.remove(fieldToRemove);
+    var request = new JsonApiRequestWrapper(new JsonApiRequest(ObjectType.SOURCE_SYSTEM, requestBody));
+
+    // When / Then
+    assertThrows(IllegalArgumentException.class, () -> controller.createSourceSystem(authentication, request, mockRequest));
+  }
+
+  private static Stream<Arguments> badSourceSystemRequest() {
+
+    return Stream.of(
+        Arguments.of("schema:url"),
+        Arguments.of("ods:translatorType"),
+        Arguments.of("ods:dataMappingIDgivenSourceSystemRequestJson"),
+        Arguments.of("schema:name"));
   }
 
   @Test


### PR DESCRIPTION
Validates that required fields are present. We could go with an actual jsonschemavalidator but that seemed like overkill. This will prevent some NPEs. 