### PR TITLE
ForceMasSchedule and Additional MAS can be sent to translator

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,8 @@
+# Aug 18 - These are all issues spring should resolve. If they remain by next release we should manually update
+
+# Issue with Jackson
+CVE-2025-52999
+# Issue with Apache Bean Utils
+CVE-2025-48734
+# Issue with netty
+CVE-2025-55163

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,8 +1,0 @@
-# Aug 18 - These are all issues spring should resolve. If they remain by next release we should manually update
-
-# Issue with Jackson
-CVE-2025-52999
-# Issue with Apache Bean Utils
-CVE-2025-48734
-# Issue with netty
-CVE-2025-55163

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.3</version>
+    <version>3.5.4</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -7,6 +7,7 @@ import static eu.dissco.orchestration.backend.utils.ControllerUtils.getAgent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.domain.ExportType;
+import eu.dissco.orchestration.backend.domain.MasScheduleData;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiListWrapper;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
@@ -20,7 +21,8 @@ import eu.dissco.orchestration.backend.service.SourceSystemService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Set;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
@@ -138,11 +140,15 @@ public class SourceSystemController {
   @ResponseStatus(HttpStatus.OK)
   @PostMapping(value = "/{prefix}/{suffix}/run", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> scheduleRunSourceSystemById(
-      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
+      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
+      @RequestBody(required = false) MasScheduleData masScheduleData)
       throws ProcessingFailedException, NotFoundException {
     var id = prefix + '/' + suffix;
+    if (masScheduleData == null) {
+      masScheduleData = new MasScheduleData();
+    }
     log.info("Received a request to start a new run for Source System: {}", id);
-    service.runSourceSystemById(id);
+    service.runSourceSystemById(id, masScheduleData);
     return ResponseEntity.accepted().build();
   }
 

--- a/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
+++ b/src/main/java/eu/dissco/orchestration/backend/controller/SourceSystemController.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
@@ -141,12 +142,10 @@ public class SourceSystemController {
   @PostMapping(value = "/{prefix}/{suffix}/run", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> scheduleRunSourceSystemById(
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
-      @RequestBody(required = false) MasScheduleData masScheduleData)
+      @RequestBody Optional<MasScheduleData> masScheduleDataOptional)
       throws ProcessingFailedException, NotFoundException {
     var id = prefix + '/' + suffix;
-    if (masScheduleData == null) {
-      masScheduleData = new MasScheduleData();
-    }
+    MasScheduleData masScheduleData = masScheduleDataOptional.orElse(new MasScheduleData());
     log.info("Received a request to start a new run for Source System: {}", id);
     service.runSourceSystemById(id, masScheduleData);
     return ResponseEntity.accepted().build();

--- a/src/main/java/eu/dissco/orchestration/backend/domain/MasScheduleData.java
+++ b/src/main/java/eu/dissco/orchestration/backend/domain/MasScheduleData.java
@@ -1,6 +1,6 @@
 package eu.dissco.orchestration.backend.domain;
 
-import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
@@ -8,13 +8,13 @@ import lombok.Value;
 @RequiredArgsConstructor
 public class MasScheduleData {
   boolean forceMasSchedule;
-  List<String> additionalSpecimenMass;
-  List<String> additionalMediaMass;
+  Set<String> specimenMass;
+  Set<String> mediaMass;
 
   public MasScheduleData(){
     forceMasSchedule = false;
-    additionalSpecimenMass = List.of();
-    additionalMediaMass = List.of();
+    specimenMass = Set.of();
+    mediaMass = Set.of();
   }
 
 }

--- a/src/main/java/eu/dissco/orchestration/backend/domain/MasScheduleData.java
+++ b/src/main/java/eu/dissco/orchestration/backend/domain/MasScheduleData.java
@@ -1,20 +1,15 @@
 package eu.dissco.orchestration.backend.domain;
 
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
 
-@Value
-@RequiredArgsConstructor
-public class MasScheduleData {
-  boolean forceMasSchedule;
-  Set<String> specimenMass;
-  Set<String> mediaMass;
+public record MasScheduleData (
+    boolean forceMasSchedule,
+    Set<String> specimenMass,
+    Set<String> mediaMass
+) {
 
   public MasScheduleData(){
-    forceMasSchedule = false;
-    specimenMass = Set.of();
-    mediaMass = Set.of();
+    this(false, Set.of(), Set.of());
   }
 
 }

--- a/src/main/java/eu/dissco/orchestration/backend/domain/MasScheduleData.java
+++ b/src/main/java/eu/dissco/orchestration/backend/domain/MasScheduleData.java
@@ -1,0 +1,20 @@
+package eu.dissco.orchestration.backend.domain;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+@Value
+@RequiredArgsConstructor
+public class MasScheduleData {
+  boolean forceMasSchedule;
+  List<String> additionalSpecimenMass;
+  List<String> additionalMediaMass;
+
+  public MasScheduleData(){
+    forceMasSchedule = false;
+    additionalSpecimenMass = List.of();
+    additionalMediaMass = List.of();
+  }
+
+}

--- a/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/SourceSystemService.java
@@ -360,12 +360,12 @@ public class SourceSystemService {
 
   private MasScheduleData setMasScheduleData(MasScheduleData masScheduleDataRequest,
       SourceSystem sourceSystem) {
-    var specimenMass = Stream.concat(masScheduleDataRequest.getSpecimenMass().stream(),
+    var specimenMass = Stream.concat(masScheduleDataRequest.specimenMass().stream(),
         sourceSystem.getOdsSpecimenMachineAnnotationServices().stream()).collect(
         Collectors.toSet());
-    var mediaMass = Stream.concat(masScheduleDataRequest.getMediaMass().stream(), sourceSystem.getOdsMediaMachineAnnotationServices()
+    var mediaMass = Stream.concat(masScheduleDataRequest.mediaMass().stream(), sourceSystem.getOdsMediaMachineAnnotationServices()
         .stream()).collect(Collectors.toSet());
-    return new MasScheduleData(masScheduleDataRequest.isForceMasSchedule(), specimenMass, mediaMass);
+    return new MasScheduleData(masScheduleDataRequest.forceMasSchedule(), specimenMass, mediaMass);
   }
 
   private void createCronJob(SourceSystem sourceSystem)
@@ -645,12 +645,12 @@ public class SourceSystemService {
     map.put("namespace", jobProperties.getNamespace());
     map.put("containerName", jobName);
     map.put("database_url", jobProperties.getDatabaseUrl());
-    map.put("forceMasSchedule", masScheduleData.isForceMasSchedule());
-    if (!masScheduleData.getSpecimenMass().isEmpty()) {
-      map.put("specimenMass", String.join(",", masScheduleData.getSpecimenMass()));
+    map.put("forceMasSchedule", masScheduleData.forceMasSchedule());
+    if (!masScheduleData.specimenMass().isEmpty()) {
+      map.put("specimenMass", String.join(",", masScheduleData.specimenMass()));
     }
-    if (!masScheduleData.getMediaMass().isEmpty()) {
-      map.put("mediaMass", String.join(",", masScheduleData.getMediaMass()));
+    if (!masScheduleData.mediaMass().isEmpty()) {
+      map.put("mediaMass", String.join(",", masScheduleData.mediaMass()));
     }
     if (isCronJob) {
       map.put("cron", generateCron());

--- a/src/main/resources/json-schema/source-system-request.json
+++ b/src/main/resources/json-schema/source-system-request.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.dissco.tech/schemas/fdo-type/source-system/0.4.0/source-system-request.json",
+  "$id": "https://schemas.dissco.tech/schemas/developer-schema/source-system/0.4.0/source-system-request.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$comment": "Source System Request Version 0.4.0",
   "title": "SourceSystemRequest",

--- a/src/main/resources/templates/biocase-cron-job.ftl
+++ b/src/main/resources/templates/biocase-cron-job.ftl
@@ -40,6 +40,14 @@ spec:
             - name: application.maxItems
               value: "${maxItems?c}"
           </#if>
+          <#if specimenMass??>
+            - name: mas.specimen-mass
+              value: ${specimenMass}
+          </#if>
+          <#if mediaMass??>
+            - name: mas.media-mass
+              value: ${mediaMass}
+          </#if>
             - name: spring.datasource.url
               value: ${database_url}
             - name: spring.datasource.username

--- a/src/main/resources/templates/biocase-translator-job.ftl
+++ b/src/main/resources/templates/biocase-translator-job.ftl
@@ -56,6 +56,16 @@ spec:
               value: https://doi.org/21.T11148/894b1e6cad57e921764e
             - name: JAVA_TOOL_OPTIONS
               value: -XX:MaxRAMPercentage=85
+            - name: mas.force-mas-schedule
+              value: ${forceMasSchedule?c}
+          <#if additionalSpecimenMass??>
+            - name: mas.additional-specimen-mass
+              value: ${additionalSpecimenMass}
+          </#if>
+          <#if additionalMediaMass??>
+            - name: mas.additional-media-mass
+              value: ${additionalMediaMass}
+          </#if>
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/src/main/resources/templates/biocase-translator-job.ftl
+++ b/src/main/resources/templates/biocase-translator-job.ftl
@@ -58,13 +58,13 @@ spec:
               value: -XX:MaxRAMPercentage=85
             - name: mas.force-mas-schedule
               value: ${forceMasSchedule?c}
-          <#if additionalSpecimenMass??>
-            - name: mas.additional-specimen-mass
-              value: ${additionalSpecimenMass}
+          <#if specimenMass??>
+            - name: mas.specimen-mass
+              value: ${specimenMass}
           </#if>
-          <#if additionalMediaMass??>
-            - name: mas.additional-media-mass
-              value: ${additionalMediaMass}
+          <#if mediaMass??>
+            - name: mas.media-mass
+              value: ${mediaMass}
           </#if>
           securityContext:
             runAsNonRoot: true

--- a/src/main/resources/templates/dwca-cron-job.ftl
+++ b/src/main/resources/templates/dwca-cron-job.ftl
@@ -44,6 +44,14 @@ spec:
             - name: application.maxItems
               value: "${maxItems?c}"
           </#if>
+          <#if specimenMass??>
+            - name: mas.specimen-mass
+              value: ${specimenMass}
+          </#if>
+          <#if mediaMass??>
+            - name: mas.media-mass
+              value: ${mediaMass}
+          </#if>
             - name: spring.datasource.url
               value: ${database_url}
             - name: spring.datasource.username

--- a/src/main/resources/templates/dwca-translator-job.ftl
+++ b/src/main/resources/templates/dwca-translator-job.ftl
@@ -60,6 +60,16 @@ spec:
               value: https://doi.org/21.T11148/894b1e6cad57e921764e
             - name: JAVA_TOOL_OPTIONS
               value: -XX:MaxRAMPercentage=85
+            - name: mas.force-mas-schedule
+              value: ${forceMasSchedule?c}
+          <#if additionalSpecimenMass??>
+            - name: mas.additional-specimen-mass
+              value: ${additionalSpecimenMass}
+          </#if>
+          <#if additionalMediaMass??>
+            - name: mas.additional-media-mass
+              value: ${additionalMediaMass}
+          </#if>
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/src/main/resources/templates/dwca-translator-job.ftl
+++ b/src/main/resources/templates/dwca-translator-job.ftl
@@ -62,13 +62,13 @@ spec:
               value: -XX:MaxRAMPercentage=85
             - name: mas.force-mas-schedule
               value: ${forceMasSchedule?c}
-          <#if additionalSpecimenMass??>
-            - name: mas.additional-specimen-mass
-              value: ${additionalSpecimenMass}
+          <#if specimenMass??>
+            - name: mas.specimen-mass
+              value: ${specimenMass}
           </#if>
-          <#if additionalMediaMass??>
-            - name: mas.additional-media-mass
-              value: ${additionalMediaMass}
+          <#if mediaMass??>
+            - name: mas.media-mass
+              value: ${mediaMass}
           </#if>
           securityContext:
             runAsNonRoot: true

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -123,7 +124,7 @@ class SourceSystemControllerTest {
     // Given
 
     // When
-    controller.scheduleRunSourceSystemById(PREFIX, SUFFIX, givenMasScheduleData());
+    controller.scheduleRunSourceSystemById(PREFIX, SUFFIX, Optional.of(givenMasScheduleData()));
 
     // Then
     then(service).should().runSourceSystemById(BARE_HANDLE, givenMasScheduleData());
@@ -134,7 +135,7 @@ class SourceSystemControllerTest {
     // Given
 
     // When
-    controller.scheduleRunSourceSystemById(PREFIX, SUFFIX, null);
+    controller.scheduleRunSourceSystemById(PREFIX, SUFFIX, Optional.empty());
 
     // Then
     then(service).should().runSourceSystemById(BARE_HANDLE, new MasScheduleData());

--- a/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/controller/SourceSystemControllerTest.java
@@ -11,6 +11,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.SYSTEM_URI;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenAgent;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenClaims;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMappingRequestJson;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasScheduleData;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystem;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRequest;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRequestJson;
@@ -21,10 +22,12 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.orchestration.backend.domain.ExportType;
+import eu.dissco.orchestration.backend.domain.MasScheduleData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequest;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiRequestWrapper;
@@ -113,6 +116,28 @@ class SourceSystemControllerTest {
     // When / Then
     assertThrows(IllegalArgumentException.class,
         () -> controller.createSourceSystem(authentication, request, mockRequest));
+  }
+
+  @Test
+  void testScheduleRunSourceSystemById() throws Exception {
+    // Given
+
+    // When
+    controller.scheduleRunSourceSystemById(PREFIX, SUFFIX, givenMasScheduleData());
+
+    // Then
+    then(service).should().runSourceSystemById(BARE_HANDLE, givenMasScheduleData());
+  }
+
+  @Test
+  void testScheduleRunSourceSystemByIdNoMasSchedule() throws Exception {
+    // Given
+
+    // When
+    controller.scheduleRunSourceSystemById(PREFIX, SUFFIX, null);
+
+    // Then
+    then(service).should().runSourceSystemById(BARE_HANDLE, new MasScheduleData());
   }
 
   @Test

--- a/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/SourceSystemServiceTest.java
@@ -13,6 +13,7 @@ import static eu.dissco.orchestration.backend.testutils.TestUtils.UPDATED;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.flattenSourceSystem;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenAgent;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenDataMapping;
+import static eu.dissco.orchestration.backend.testutils.TestUtils.givenMasScheduleData;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystem;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemRequest;
 import static eu.dissco.orchestration.backend.testutils.TestUtils.givenSourceSystemResponse;
@@ -37,6 +38,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import eu.dissco.orchestration.backend.domain.ExportType;
+import eu.dissco.orchestration.backend.domain.MasScheduleData;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
@@ -444,7 +446,20 @@ class SourceSystemServiceTest {
         batchV1Api.createNamespacedJob(eq(NAMESPACE), any(V1Job.class))).willReturn(createJob);
 
     // Then
-    assertDoesNotThrow(() -> service.runSourceSystemById(HANDLE));
+    assertDoesNotThrow(() -> service.runSourceSystemById(HANDLE, new MasScheduleData()));
+  }
+
+  @Test
+  void testRunSourceSystemByIdMasScheduleData() {
+    // Given
+    var sourceSystem = givenSourceSystem();
+    given(repository.getSourceSystem(HANDLE)).willReturn(sourceSystem);
+    var createJob = mock(APIcreateNamespacedJobRequest.class);
+    given(
+        batchV1Api.createNamespacedJob(eq(NAMESPACE), any(V1Job.class))).willReturn(createJob);
+
+    // Then
+    assertDoesNotThrow(() -> service.runSourceSystemById(HANDLE, givenMasScheduleData()));
   }
 
   @Test
@@ -453,7 +468,8 @@ class SourceSystemServiceTest {
     given(repository.getSourceSystem(HANDLE)).willReturn(null);
 
     // When / Then
-    assertThrowsExactly(NotFoundException.class, () -> service.runSourceSystemById(HANDLE));
+    assertThrowsExactly(NotFoundException.class, () -> service.runSourceSystemById(HANDLE,
+        new MasScheduleData()));
   }
 
   @Test
@@ -463,7 +479,8 @@ class SourceSystemServiceTest {
     given(repository.getSourceSystem(HANDLE)).willReturn(sourceSystem);
 
     // When / Then
-    assertThrowsExactly(NotFoundException.class, () -> service.runSourceSystemById(HANDLE));
+    assertThrowsExactly(NotFoundException.class, () -> service.runSourceSystemById(HANDLE,
+        new MasScheduleData()));
   }
 
   @ParameterizedTest

--- a/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
+++ b/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.orchestration.backend.domain.AgentRoleType;
+import eu.dissco.orchestration.backend.domain.MasScheduleData;
 import eu.dissco.orchestration.backend.domain.ObjectType;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.orchestration.backend.domain.jsonapi.JsonApiLinks;
@@ -456,6 +457,15 @@ public class TestUtils {
     return Map.of(
         "orcid", OBJECT_CREATOR
     );
+  }
+
+  public static MasScheduleData givenMasScheduleData(){
+    return new MasScheduleData(
+        true,
+        List.of(HANDLE_ALT),
+        List.of(HANDLE_ALT)
+    );
+
   }
 
 

--- a/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
+++ b/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TestUtils {
 
@@ -462,8 +463,8 @@ public class TestUtils {
   public static MasScheduleData givenMasScheduleData(){
     return new MasScheduleData(
         true,
-        List.of(HANDLE_ALT),
-        List.of(HANDLE_ALT)
+        Set.of(HANDLE_ALT),
+        Set.of(HANDLE_ALT)
     );
 
   }

--- a/src/test/resources/templates/dwca-translator-job.ftl
+++ b/src/test/resources/templates/dwca-translator-job.ftl
@@ -32,6 +32,16 @@ spec:
                 secretKeyRef:
                   name: aws-secrets
                   key: rabbitmq-username
+            - name: mas.force-mas-schedule
+              value: ${forceMasSchedule?c}
+          <#if additionalSpecimenMass??>
+            - name: mas.additional-specimen-mass
+              value: ${additionalSpecimenMass}
+          </#if>
+          <#if additionalMediaMass??>
+            - name: mas.additional-media-mass
+              value: ${additionalMediaMass}
+          </#if>
             - name: webclient.sourceSystemId
               value: ${sourceSystemId}
             - name: spring.datasource.url

--- a/src/test/resources/templates/geocase-translator-job.ftl
+++ b/src/test/resources/templates/geocase-translator-job.ftl
@@ -35,6 +35,16 @@ spec:
                 secretKeyRef:
                   name: aws-secrets
                   key: rabbitmq-username
+            - name: mas.force-mas-schedule
+              value: ${forceMasSchedule?c}
+          <#if additionalSpecimenMass??>
+            - name: mas.additional-specimen-mass
+              value: ${additionalSpecimenMass}
+          </#if>
+          <#if additionalMediaMass??>
+            - name: mas.additional-media-mass
+              value: ${additionalMediaMass}
+          </#if>
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
three fields can be set in manual data ingestion: 
- `forceMasSchedule`: normally, MASs will only run on new specimens. This flag will mean MASs will be run on equal and updated specimens too
- `additionalSpecimenMass`: additional MASs to run on the specimens. These MASs are run **in addition to** the MASs already associated with the given source system
- `additionalMediaMass`: additional MASs to run on any media in the dataset. Same as above

These MASs are then combined with the MASs in the source system and sent to the translator