### PR TITLE
Automatically generate topic name

### DIFF
--- a/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceService.java
@@ -109,7 +109,7 @@ public class MachineAnnotationServiceService {
 
 	private final FdoProperties fdoProperties;
 
-	private static String getName(String pid) {
+	private static String getTopicName(String pid) {
 		return pid.substring(pid.lastIndexOf('/') + 1).toLowerCase();
 	}
 
@@ -147,8 +147,8 @@ public class MachineAnnotationServiceService {
 			.withSchemaLicense(mas.getSchemaLicense())
 			.withSchemaContactPoint(mas.getSchemaContactPoint())
 			.withOdsSlaDocumentation(mas.getOdsSlaDocumentation())
-			.withOdsTopicName(mas.getOdsTopicName())
-			.withOdsMaxReplicas(mas.getOdsMaxReplicas())
+			.withOdsTopicName(getTopicName(mas.getId()))
+			.withOdsMaxReplicas(getMaxReplicas(mas.getOdsMaxReplicas()))
 			.withOdsBatchingPermitted(mas.getOdsBatchingPermitted())
 			.withOdsTimeToLive(mas.getOdsTimeToLive())
 			.withOdsHasTombstoneMetadata(buildTombstoneMetadata(tombstoningAgent,
@@ -191,7 +191,7 @@ public class MachineAnnotationServiceService {
 						toMap(queue -> (((JsonObject) queue).get(METADATA).getAsJsonObject()).get("name").getAsString(),
 								queue -> queue));
 			for (var machineAnnotationService : existingMasList) {
-				var name = getName(machineAnnotationService.getId());
+				var name = getTopicName(machineAnnotationService.getId());
 				var expectedRabbitQueue = JsonParser.parseString(createRabbitQueueResource(name));
 				var existingRabbitQueue = existingRabbitQueueMap.get(MAS_PREFIX + name + QUEUE);
 				if (existingRabbitQueue == null) {
@@ -226,7 +226,7 @@ public class MachineAnnotationServiceService {
 			}
 			existingRabbitQueueMap.keySet()
 				.removeAll(existingMasList.stream()
-					.map(mas -> MAS_PREFIX + getName(mas.getId()) + QUEUE)
+					.map(mas -> MAS_PREFIX + getTopicName(mas.getId()) + QUEUE)
 					.collect(Collectors.toSet()));
 			for (var existingKeda : existingRabbitQueueMap.entrySet()) {
 				log.warn("Found a Rabbit Queue Resource: {} without a machine annotation service, deleting it",
@@ -255,7 +255,7 @@ public class MachineAnnotationServiceService {
 						binding -> (((JsonObject) binding).get(METADATA).getAsJsonObject()).get("name").getAsString(),
 						binding -> binding));
 			for (var machineAnnotationService : existingMasList) {
-				var name = getName(machineAnnotationService.getId());
+				var name = getTopicName(machineAnnotationService.getId());
 				var expectedRabbitBinding = JsonParser.parseString(createRabbitBindingResource(name));
 				var existingRabbitBinding = existingRabbitBindingMap.get(MAS_PREFIX + name + BINDING);
 				if (existingRabbitBinding == null) {
@@ -290,7 +290,7 @@ public class MachineAnnotationServiceService {
 			}
 			existingRabbitBindingMap.keySet()
 				.removeAll(existingMasList.stream()
-					.map(mas -> MAS_PREFIX + getName(mas.getId()) + BINDING)
+					.map(mas -> MAS_PREFIX + getTopicName(mas.getId()) + BINDING)
 					.collect(Collectors.toSet()));
 			for (var existingKeda : existingRabbitBindingMap.entrySet()) {
 				log.warn("Found a Rabbit Binding Resource: {} without a machine annotation service, deleting it",
@@ -322,7 +322,7 @@ public class MachineAnnotationServiceService {
 				.collect(toMap(keda -> (((JsonObject) keda).get(METADATA).getAsJsonObject()).get("name").getAsString(),
 						keda -> keda));
 			for (var machineAnnotationService : existingMasList) {
-				var name = getName(machineAnnotationService.getId());
+				var name = getTopicName(machineAnnotationService.getId());
 				var expectedKedaObject = createKedaFiles(machineAnnotationService, name);
 				var existingKedaObject = existingKedaMap.get(name + SCALED_OBJECT);
 				if (existingKedaObject == null) {
@@ -357,7 +357,7 @@ public class MachineAnnotationServiceService {
 			}
 			existingKedaMap.keySet()
 				.removeAll(existingMasList.stream()
-					.map(mas -> getName(mas.getId()) + SCALED_OBJECT)
+					.map(mas -> getTopicName(mas.getId()) + SCALED_OBJECT)
 					.collect(Collectors.toSet()));
 			for (var existingKeda : existingKedaMap.entrySet()) {
 				log.warn("Found a KEDA resource: {} without a machine annotation service, deleting it",
@@ -381,8 +381,8 @@ public class MachineAnnotationServiceService {
 			.collect(toMap(mas -> mas.getMetadata().getName(), mas -> mas));
 		for (var machineAnnotationService : existingMasList) {
 			var expectedMasDeploy = getV1Deployment(machineAnnotationService,
-					getName(machineAnnotationService.getId()));
-			var existingMasDeploy = existingDeployment.get(getName(machineAnnotationService.getId()) + DEPLOYMENT);
+					getTopicName(machineAnnotationService.getId()));
+			var existingMasDeploy = existingDeployment.get(getTopicName(machineAnnotationService.getId()) + DEPLOYMENT);
 			if (existingMasDeploy == null) {
 				log.warn("Found a machine annotation service: {} without a deployment, creating one",
 						machineAnnotationService.getId());
@@ -403,7 +403,9 @@ public class MachineAnnotationServiceService {
 		}
 		existingDeployment.keySet()
 			.removeAll(
-					existingMasList.stream().map(mas -> getName(mas.getId()) + DEPLOYMENT).collect(Collectors.toSet()));
+					existingMasList.stream()
+						.map(mas -> getTopicName(mas.getId()) + DEPLOYMENT)
+						.collect(Collectors.toSet()));
 		for (var existingDeploy : existingDeployment.values()) {
 			log.warn("Found a deployment: {} without a machine annotation service, deleting it",
 					existingDeploy.getMetadata().getName());
@@ -426,7 +428,6 @@ public class MachineAnnotationServiceService {
 		var requestBody = fdoRecordService.buildCreateRequest(masRequest, ObjectType.MAS);
 		try {
 			var handle = handleComponent.postHandle(requestBody);
-			setDefaultMas(masRequest, handle);
 			var mas = buildMachineAnnotationService(masRequest, 1, agent, handle, Instant.now());
 			repository.createMachineAnnotationService(mas);
 			createDeployment(mas);
@@ -463,8 +464,8 @@ public class MachineAnnotationServiceService {
 			.withSchemaLicense(mas.getSchemaLicense())
 			.withSchemaContactPoint(buildContactPoint(mas.getSchemaContactPoint()))
 			.withOdsSlaDocumentation(mas.getOdsSlaDocumentation())
-			.withOdsTopicName(mas.getOdsTopicName())
-			.withOdsMaxReplicas(mas.getOdsMaxReplicas())
+			.withOdsTopicName(getTopicName(handle))
+			.withOdsMaxReplicas(getMaxReplicas(mas.getOdsMaxReplicas()))
 			.withOdsBatchingPermitted(mas.getOdsBatchingPermitted())
 			.withOdsTimeToLive(mas.getOdsTimeToLive())
 			.withOdsHasSecretVariables(mas.getOdsHasSecretVariables())
@@ -480,13 +481,11 @@ public class MachineAnnotationServiceService {
 		return filter;
 	}
 
-	private void setDefaultMas(MachineAnnotationServiceRequest mas, String handle) {
-		if (mas.getOdsTopicName() == null) {
-			mas.setOdsTopicName(getName(handle));
+	private static Integer getMaxReplicas(Integer maxReplicas) {
+		if (maxReplicas == null || maxReplicas <= 0) {
+			return 1;
 		}
-		if (mas.getOdsMaxReplicas() == null || mas.getOdsMaxReplicas() <= 0) {
-			mas.setOdsMaxReplicas(1);
-		}
+		return maxReplicas;
 	}
 
 	private void createDeployment(MachineAnnotationService mas) throws ProcessingFailedException {
@@ -506,7 +505,7 @@ public class MachineAnnotationServiceService {
 	}
 
 	private boolean deployRabbitBindingToCluster(MachineAnnotationService mas) throws KubernetesFailedException {
-		var name = getName(mas.getId());
+		var name = getTopicName(mas.getId());
 		try {
 			var rabbitResource = createRabbitBindingResource(name);
 			var rabbitObject = JsonParser.parseString(rabbitResource);
@@ -529,7 +528,7 @@ public class MachineAnnotationServiceService {
 	}
 
 	private void deployRabbitQueueToCluster(MachineAnnotationService mas) throws KubernetesFailedException {
-		var name = getName(mas.getId());
+		var name = getTopicName(mas.getId());
 		try {
 			var rabbitResource = createRabbitQueueResource(name);
 			var rabbitObject = JsonParser.parseString(rabbitResource);
@@ -568,7 +567,7 @@ public class MachineAnnotationServiceService {
 	}
 
 	private boolean deployKedaToCluster(MachineAnnotationService mas) throws KubernetesFailedException {
-		var name = getName(mas.getId());
+		var name = getTopicName(mas.getId());
 		try {
 			var keda = createKedaFiles(mas, name);
 			customObjectsApi
@@ -590,7 +589,7 @@ public class MachineAnnotationServiceService {
 	}
 
 	private boolean deployMasToCluster(MachineAnnotationService mas, boolean create) throws KubernetesFailedException {
-		var shortPid = getName(mas.getId());
+		var shortPid = getTopicName(mas.getId());
 		try {
 			var deployment = getV1Deployment(mas, shortPid);
 			if (create) {
@@ -719,7 +718,7 @@ public class MachineAnnotationServiceService {
 		var request = fdoRecordService.buildRollbackCreateRequest(mas.getId());
 		handleComponent.rollbackHandleCreation(request);
 		repository.rollbackMasCreation(mas.getId());
-		var name = getName(mas.getId());
+		var name = getTopicName(mas.getId());
 		if (rollbackDeployment) {
 			try {
 				appsV1Api.deleteNamespacedDeployment(name + DEPLOYMENT, properties.getNamespace()).execute();
@@ -779,7 +778,6 @@ public class MachineAnnotationServiceService {
 		var currentMasOptional = repository.getActiveMachineAnnotationService(id);
 		if (currentMasOptional.isPresent()) {
 			var currentMas = currentMasOptional.get();
-			setDefaultMas(masRequest, id);
 			var machineAnnotationService = buildMachineAnnotationService(masRequest, currentMas.getSchemaVersion() + 1,
 					agent, id, Instant.now());
 			if (isEqual(machineAnnotationService, currentMas)) {
@@ -834,7 +832,7 @@ public class MachineAnnotationServiceService {
 
 	private void updateKedaResource(MachineAnnotationService mas, MachineAnnotationService rollbackRecord)
 			throws KubernetesFailedException, ProcessingFailedException {
-		var name = getName(mas.getId());
+		var name = getTopicName(mas.getId());
 		try {
 			customObjectsApi
 				.deleteNamespacedCustomObject(kubernetesProperties.getKedaGroup(),
@@ -936,7 +934,7 @@ public class MachineAnnotationServiceService {
 	}
 
 	private void deleteDeployment(MachineAnnotationService currentMas) throws ProcessingFailedException {
-		var name = getName(currentMas.getId());
+		var name = getTopicName(currentMas.getId());
 		try {
 			appsV1Api.deleteNamespacedDeployment(name + DEPLOYMENT, properties.getNamespace()).execute();
 		}
@@ -968,7 +966,7 @@ public class MachineAnnotationServiceService {
 
 	private void removeRabbitResources(MachineAnnotationService currentMas) {
 		try {
-			var name = getName(currentMas.getId());
+			var name = getTopicName(currentMas.getId());
 			customObjectsApi
 				.deleteNamespacedCustomObject(kubernetesProperties.getRabbitGroup(),
 						kubernetesProperties.getRabbitVersion(), properties.getNamespace(),

--- a/src/main/resources/json-schema/machine-annotation-service-request.json
+++ b/src/main/resources/json-schema/machine-annotation-service-request.json
@@ -134,10 +134,6 @@
       "type": "string",
       "description": "Link to SLA documentation"
     },
-    "ods:topicName": {
-      "type": "string",
-      "description": "Kafka topic through which the MAS receives messages. Defaults to PID of MAS"
-    },
     "ods:maxReplicas": {
       "type": "integer",
       "description": "The maximum amount of this MAS that can simultaneously run without causing issues"

--- a/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/orchestration/backend/service/MachineAnnotationServiceServiceTest.java
@@ -176,7 +176,7 @@ class MachineAnnotationServiceServiceTest {
 		var envList = new ArrayList<>(List.of(new V1EnvVar().name("MAS_NAME").value("A Machine Annotation Service"),
 				new V1EnvVar().name("MAS_ID").value("20.5000.1025/GW0-POP-XSL"),
 				new V1EnvVar().name("RABBITMQ_HOST").value("rabbitmq-cluster.rabbitmq.svc.cluster.local"),
-				new V1EnvVar().name("RABBITMQ_QUEUE").value("mas-fancy-topic-name-queue"),
+				new V1EnvVar().name("RABBITMQ_QUEUE").value("mas-gw0-pop-xsl-queue"),
 				new V1EnvVar().name("RABBITMQ_USER")
 					.valueFrom(new V1EnvVarSource()
 						.secretKeyRef(new V1SecretKeySelector().key("rabbitmq-username").name("aws-secrets"))),
@@ -279,7 +279,6 @@ class MachineAnnotationServiceServiceTest {
 				new JsonApiLinks(MAS_PATH));
 
 		var masRequest = givenMasRequest().withSchemaContactPoint(null)
-			.withOdsTopicName(null)
 			.withOdsMaxReplicas(maxReplicas);
 		given(handleComponent.postHandle(any())).willReturn(BARE_HANDLE);
 		given(fdoProperties.getMasType()).willReturn(MAS_TYPE_DOI);

--- a/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
+++ b/src/test/java/eu/dissco/orchestration/backend/testutils/TestUtils.java
@@ -323,7 +323,6 @@ public class TestUtils {
 			.withSchemaLicense("https://www.apache.org/licenses/LICENSE-2.0")
 			.withOdsDependency(List.of())
 			.withSchemaContactPoint(new SchemaContactPoint().withSchemaEmail("dontmail@dissco.eu"))
-			.withOdsTopicName("fancy-topic-name")
 			.withOdsMaxReplicas(5)
 			.withOdsBatchingPermitted(false)
 			.withOdsTimeToLive(TTL)
@@ -375,12 +374,16 @@ public class TestUtils {
 			.withSchemaMaintainer(givenAgent())
 			.withSchemaLicense("https://www.apache.org/licenses/LICENSE-2.0")
 			.withSchemaContactPoint(new SchemaContactPoint__1().withSchemaEmail("dontmail@dissco.eu"))
-			.withOdsTopicName("fancy-topic-name")
+			.withOdsTopicName(stripId(id))
 			.withOdsMaxReplicas(5)
 			.withOdsBatchingPermitted(false)
 			.withOdsTimeToLive(ttl)
 			.withOdsHasEnvironmentalVariables(givenMasEnvironment())
 			.withOdsHasSecretVariables(givenMasSecrets());
+	}
+
+	private static String stripId(String pid) {
+		return pid.substring(pid.lastIndexOf('/') + 1).toLowerCase();
 	}
 
 	public static MachineAnnotationService givenTombstoneMas() {


### PR DESCRIPTION
[Jira](https://naturalis.atlassian.net/browse/DD-3081)

The MAS topic name is currently internally managed, unless a user overwrites it in a request. By default, the topic is the lower-case suffix of the PID, but it can be overwritten by a user. Instead of adding a check to ensure the topic isn’t null in a request, the topic is be omitted from the request entirely, and be **fully managed by the orchestration service.** 

Continuing to call this `topicName` is a relic from our kafka days but changing the field name and altering existing MASs would be a pain :upside_down_face: 

